### PR TITLE
jwt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,7 @@ modiraa2\
 application.properties
 application.yml
 application-aws.yml
-JwtProperties.java
+application-jwt.yml
+application-oauth.yml
+application-server.yml
+application-spring.yml

--- a/src/main/java/com/example/modiraa/ModiraaApplication.java
+++ b/src/main/java/com/example/modiraa/ModiraaApplication.java
@@ -2,9 +2,7 @@ package com.example.modiraa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import javax.annotation.PostConstruct;
 import java.util.TimeZone;
@@ -12,11 +10,6 @@ import java.util.TimeZone;
 @EnableJpaAuditing
 @SpringBootApplication
 public class ModiraaApplication {
-
-    @Bean
-    public BCryptPasswordEncoder passwordEncoder(){
-        return new BCryptPasswordEncoder();
-    }
 
     public static void main(String[] args) {
         SpringApplication.run(ModiraaApplication.class, args);

--- a/src/main/java/com/example/modiraa/ModiraaApplication.java
+++ b/src/main/java/com/example/modiraa/ModiraaApplication.java
@@ -1,7 +1,7 @@
 package com.example.modiraa;
 
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -18,19 +18,12 @@ public class ModiraaApplication {
         return new BCryptPasswordEncoder();
     }
 
-    public static final String APPLICATION_LOCATIONS = "spring.config.location="
-            + "classpath:application-aws.yml,"
-            + "classpath:application.yml";
-
     public static void main(String[] args) {
-        new SpringApplicationBuilder(ModiraaApplication.class)
-                .properties(APPLICATION_LOCATIONS)
-                .run(args);
+        SpringApplication.run(ModiraaApplication.class, args);
     }
 
     @PostConstruct
     public void started(){
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-
     }
 }

--- a/src/main/java/com/example/modiraa/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/modiraa/auth/UserDetailsServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.modiraa.auth;
 import com.example.modiraa.model.Member;
 import com.example.modiraa.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -14,7 +15,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     private final MemberRepository memberRepository;
 
-    public UserDetailsImpl loadUserByUsername(String nickname) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
         Member member = memberRepository.findByNickname(nickname)
                 .orElseThrow(() -> new UsernameNotFoundException("Can't find " + nickname));
 

--- a/src/main/java/com/example/modiraa/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/modiraa/auth/UserDetailsServiceImpl.java
@@ -1,22 +1,22 @@
 package com.example.modiraa.auth;
 
-import com.example.modiraa.repository.MemberRepository;
 import com.example.modiraa.model.Member;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.example.modiraa.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 
 @Service
-public class UserDetailsServiceImpl implements UserDetailsService{
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
 
-    @Autowired
-    private MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
-    public UserDetailsImpl loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByUsername(username)
-                .orElseThrow(() -> new UsernameNotFoundException("Can't find " + username));
+    public UserDetailsImpl loadUserByUsername(String nickname) throws UsernameNotFoundException {
+        Member member = memberRepository.findByNickname(nickname)
+                .orElseThrow(() -> new UsernameNotFoundException("Can't find " + nickname));
 
         return new UserDetailsImpl(member);
     }

--- a/src/main/java/com/example/modiraa/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/modiraa/config/WebSecurityConfig.java
@@ -1,7 +1,8 @@
 package com.example.modiraa.config;
 
-import com.example.modiraa.config.jwt.FormLoginFilter;
+import com.example.modiraa.config.jwt.JwtAuthenticationFilter;
 import com.example.modiraa.config.jwt.JwtAuthorizationFilter;
+import com.example.modiraa.config.jwt.JwtProperties;
 import com.example.modiraa.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
@@ -29,6 +30,7 @@ public class WebSecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
     private final MemberRepository memberRepository;
+    private final JwtProperties jwtProperties;
 
     @Bean   // 비밀번호 암호화
     public BCryptPasswordEncoder passwordEncoder() {
@@ -71,8 +73,8 @@ public class WebSecurityConfig {
                 // 토큰을 활용하면 세션이 필요 없으므로 STATELESS로 설정하여 Session을 사용하지 않는다.
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .addFilterBefore(new FormLoginFilter(authenticationManager(authenticationConfiguration)), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(new JwtAuthorizationFilter(authenticationManager(authenticationConfiguration), memberRepository), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(authenticationManager(authenticationConfiguration), jwtProperties), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthorizationFilter(authenticationManager(authenticationConfiguration), memberRepository, jwtProperties), UsernamePasswordAuthenticationFilter.class)
         ;
 
         return http.build();

--- a/src/main/java/com/example/modiraa/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/modiraa/config/WebSecurityConfig.java
@@ -8,13 +8,14 @@ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -24,29 +25,30 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableWebSecurity // 스프링 Security 지원을 가능하게 함
 @EnableGlobalMethodSecurity(securedEnabled = true)
 @RequiredArgsConstructor
-public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+public class WebSecurityConfig {
 
+    private final AuthenticationConfiguration authenticationConfiguration;
     private final MemberRepository memberRepository;
 
     @Bean   // 비밀번호 암호화
-    public BCryptPasswordEncoder encodePassword() {
+    public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
-    @Override // Bean 에 등록
-    public AuthenticationManager authenticationManagerBean() throws Exception {
-        return super.authenticationManagerBean();
+    AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
     // 정적 자원에 대해서는 Security 설정을 적용하지 않음.
-    @Override
-    public void configure(WebSecurity web) {
-        web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+
+    @Bean
+    protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf().disable();
         http.cors().configurationSource(corsConfigurationSource());
         http.headers().frameOptions().disable(); //h2-console 보기
@@ -69,9 +71,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 // 토큰을 활용하면 세션이 필요 없으므로 STATELESS로 설정하여 Session을 사용하지 않는다.
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .addFilterBefore(new FormLoginFilter(authenticationManager()), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(new JwtAuthorizationFilter(authenticationManager(), memberRepository), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new FormLoginFilter(authenticationManager(authenticationConfiguration)), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthorizationFilter(authenticationManager(authenticationConfiguration), memberRepository), UsernamePasswordAuthenticationFilter.class)
         ;
+
+        return http.build();
     }
 
 

--- a/src/main/java/com/example/modiraa/config/jwt/AuthTokensGenerator.java
+++ b/src/main/java/com/example/modiraa/config/jwt/AuthTokensGenerator.java
@@ -14,11 +14,11 @@ public class AuthTokensGenerator {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthTokens generate(String username) {
+    public AuthTokens generate(String nickname) {
         long now = (new Date()).getTime();
         Date accessTokenExpiredAt = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
 
-        String accessToken = jwtTokenProvider.generate(username, accessTokenExpiredAt);
+        String accessToken = jwtTokenProvider.generate(nickname, accessTokenExpiredAt);
 
         return AuthTokens.of(accessToken, BEARER_TYPE, ACCESS_TOKEN_EXPIRE_TIME / 1000L);
     }

--- a/src/main/java/com/example/modiraa/config/jwt/AuthTokensGenerator.java
+++ b/src/main/java/com/example/modiraa/config/jwt/AuthTokensGenerator.java
@@ -8,19 +8,17 @@ import java.util.Date;
 @Component
 @RequiredArgsConstructor
 public class AuthTokensGenerator {
-    private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
-
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
 
     public AuthTokens generate(String nickname) {
         long now = (new Date()).getTime();
-        Date accessTokenExpiredAt = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        long AccessTokenExpireTime = jwtProperties.getAccessExpiration();
+        Date accessTokenExpiredAt = new Date(now + AccessTokenExpireTime);
 
         String accessToken = jwtTokenProvider.generate(nickname, accessTokenExpiredAt);
 
-        return AuthTokens.of(accessToken, BEARER_TYPE, ACCESS_TOKEN_EXPIRE_TIME / 1000L);
+        return AuthTokens.of(accessToken, jwtProperties.getTokenPrefix(), AccessTokenExpireTime / 1000L);
     }
 
     public Long extractMemberId(String accessToken) {

--- a/src/main/java/com/example/modiraa/config/jwt/FormLoginFilter.java
+++ b/src/main/java/com/example/modiraa/config/jwt/FormLoginFilter.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.util.Date;
 
 //스프링 시큐리티에서 UsernamePasswordAuthenticationFilter 가 있음.
-// /login 요청해서 username, password 전송하면 (psot)
+// /login 요청해서 nickname, password 전송하면 (psot)
 //UsernamePasswordAuthenticationFilter 동작을 함.
 public class FormLoginFilter extends UsernamePasswordAuthenticationFilter {
 
@@ -31,11 +31,11 @@ public class FormLoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
         System.out.println("JwtAuthenticationFilter : 로그인 시도중");
-        // 1.username, password 받아서
+        // 1.nickname, password 받아서
         // 2. 정상인지 로그인 시도를 해보는 것. authenticationManager로 로그인 시도를 하면!!
         // PrincipalDetailsService가 호출 loadUserByUsername() 함수 실행됨.
         // PrincipalDetailsService의 loadUserByUsername()함수가 실행된 후 정상이면 authentication이 리턴됨.
-        // DB에 있는 username과 password가 일치한다.
+        // DB에 있는 nickname과 password가 일치한다.
         try {
             ObjectMapper om = new ObjectMapper();
             LoginRequestDto loginRequestDto = om.readValue(request.getInputStream(), LoginRequestDto.class); //유저정보 담기
@@ -44,7 +44,6 @@ public class FormLoginFilter extends UsernamePasswordAuthenticationFilter {
 
             UsernamePasswordAuthenticationToken authenticationToken =
                     new UsernamePasswordAuthenticationToken(loginRequestDto.getUsername(), loginRequestDto.getPassword());
-
 
             Authentication authentication =
                     getAuthenticationManager().authenticate(authenticationToken);
@@ -69,7 +68,7 @@ public class FormLoginFilter extends UsernamePasswordAuthenticationFilter {
         String jwtToken = JWT.create()
                 .withSubject("cos토큰")
                 .withExpiresAt(new Date(System.currentTimeMillis() + JwtProperties.EXPIRATION_TIME))
-                .withClaim("username", userDetails.getMember().getUsername())
+                .withClaim("nickname", userDetails.getMember().getNickname())
                 .sign(Algorithm.HMAC512(JwtProperties.SECRET));
 
         response.addHeader(JwtProperties.HEADER_STRING, JwtProperties.TOKEN_PREFIX + jwtToken);
@@ -79,7 +78,7 @@ public class FormLoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
         System.out.println(failed.getMessage());
-        response.setStatus(400);
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(failed.getMessage());
     }

--- a/src/main/java/com/example/modiraa/config/jwt/FormLoginProvider.java
+++ b/src/main/java/com/example/modiraa/config/jwt/FormLoginProvider.java
@@ -1,6 +1,5 @@
 package com.example.modiraa.config.jwt;
 
-import com.example.modiraa.auth.UserDetailsImpl;
 import com.example.modiraa.auth.UserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -8,6 +7,7 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +23,7 @@ public class FormLoginProvider implements AuthenticationProvider {
         String username = (String)authentication.getPrincipal();
         String password = (String)authentication.getCredentials();
 
-        UserDetailsImpl userDetails = userDetailsServiceImpl.loadUserByUsername(username);
+        UserDetails userDetails = userDetailsServiceImpl.loadUserByUsername(username);
 
         //인코딩된 암호는 시간마다 같은 값도 변경 되기 때문에 matches 함수를 이용해 비교.
         if(passwordEncoder.matches(password, userDetails.getPassword())) {

--- a/src/main/java/com/example/modiraa/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/modiraa/config/jwt/JwtAuthorizationFilter.java
@@ -11,6 +11,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.stereotype.Component;
 
@@ -28,42 +29,36 @@ import java.io.IOException;
 public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
     private final MemberRepository memberRepository;
+    private final JwtProperties jwtProperties;
 
-    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, MemberRepository memberRepository) {
+    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, MemberRepository memberRepository, JwtProperties jwtProperties) {
         super(authenticationManager);
         this.memberRepository = memberRepository;
+        this.jwtProperties = jwtProperties;
     }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
-            throws IOException, ServletException {
-        //헤더 확인
-        String header = request.getHeader(JwtProperties.HEADER_STRING);
-        if (header == null || !header.startsWith(JwtProperties.TOKEN_PREFIX)) {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String header = request.getHeader(jwtProperties.getAccessHeader());
+
+        if (header == null || !header.startsWith(jwtProperties.getTokenPrefix())) {
             chain.doFilter(request, response);
             return;
         }
 
-        //JWT 토큰을 검증을 해서 정상적인 사용자인지 확인
-        String jwtToken = request.getHeader(JwtProperties.HEADER_STRING)
-                .replace("Bearer ", "");
+        // JWT 토큰을 검증해서 정상적인 사용자인지 확인
+        String jwtToken = request.getHeader(jwtProperties.getAccessHeader()).replace(jwtProperties.getTokenPrefix(), "");
 
-        System.out.println("header : " + header);
+        log.info("header {}", header);
 
         String nickname =
-                JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(jwtToken).getClaim("nickname").asString();
+                JWT.require(Algorithm.HMAC512(jwtProperties.getSecretKey())).build().verify(jwtToken).getClaim(jwtProperties.getNicknameClaim()).asString();
 
-        //서명이 정상적으로 됨.
+        // 서명이 정상적으로 됨
         if (nickname != null) {
-            Member memberEntity = memberRepository.findByNickname(nickname).orElseThrow(
-                    () -> new IllegalArgumentException("nickname이 없습니다.")
-            );
-
-            UserDetailsImpl userDetails = new UserDetailsImpl(memberEntity);
-
+            UserDetails userDetails = getUserDetailsFromNickname(nickname);
             //Jwt 토큰 서명을 통해서 서명이 정상이면 Authentication 객체를 만들어 준다.
-            Authentication authentication =
-                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
             //홀더에 검증이 완료된 정보 값 넣어준다. -> 이제 controller 에서 @AuthenticationPrincipal UserDetailsImpl userDetails 로 정보를 꺼낼 수 있다.
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
@@ -71,13 +66,21 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
         }
     }
 
+    private UserDetails getUserDetailsFromNickname(String nickname) {
+        Member member = memberRepository.findByNickname(nickname).orElseThrow(
+                () -> new IllegalArgumentException("nickname이 없습니다.")
+        );
+
+        return new UserDetailsImpl(member);
+    }
+
     /**
-     * Jwt Token을 복호화 하여 이름을 얻는다.
+     * Jwt Token을 복호화 하여 Member를 얻는다.
      */
     public String getNicknameFromJwt(String token) {
 
         String nickname =
-                JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token).getClaim("nickname").asString();
+                JWT.require(Algorithm.HMAC512(jwtProperties.getSecretKey())).build().verify(token).getClaim(jwtProperties.getNicknameClaim()).asString();
 
         if (nickname != null) {
             Member memberEntity = memberRepository.findByNickname(nickname).orElseThrow(
@@ -94,7 +97,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
     public Member getMemberFromJwt(String token) {
 
         String nickname =
-                JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token).getClaim("nickname").asString();
+                JWT.require(Algorithm.HMAC512(jwtProperties.getSecretKey())).build().verify(token).getClaim(jwtProperties.getNicknameClaim()).asString();
 
         if (nickname != null) {
             Member memberEntity = memberRepository.findByNickname(nickname).orElseThrow(
@@ -114,7 +117,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
     private Jws<Claims> getClaims(String jwt) {
         try {
-            return Jwts.parser().setSigningKey(JwtProperties.SECRET.getBytes()).parseClaimsJws(jwt);
+            return Jwts.parser().setSigningKey(jwtProperties.getSecretKey().getBytes()).parseClaimsJws(jwt);
         } catch (SignatureException ex) {
             log.error("Invalid JWT signature");
             throw ex;

--- a/src/main/java/com/example/modiraa/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/modiraa/config/jwt/JwtAuthorizationFilter.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 @Component
 public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
-    private MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
     public JwtAuthorizationFilter(AuthenticationManager authenticationManager, MemberRepository memberRepository) {
         super(authenticationManager);
@@ -39,7 +39,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
             throws IOException, ServletException {
         //헤더 확인
         String header = request.getHeader(JwtProperties.HEADER_STRING);
-        if(header == null || !header.startsWith(JwtProperties.TOKEN_PREFIX)) {
+        if (header == null || !header.startsWith(JwtProperties.TOKEN_PREFIX)) {
             chain.doFilter(request, response);
             return;
         }
@@ -48,22 +48,22 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
         String jwtToken = request.getHeader(JwtProperties.HEADER_STRING)
                 .replace("Bearer ", "");
 
-        System.out.println("header : "+header);
+        System.out.println("header : " + header);
 
-        String username =
-                JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(jwtToken).getClaim("username").asString();
+        String nickname =
+                JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(jwtToken).getClaim("nickname").asString();
 
         //서명이 정상적으로 됨.
-        if(username != null) {
-            Member memberEntity = memberRepository.findByUsername(username).orElseThrow(
-                    ()-> new IllegalArgumentException("username이 없습니다.")
+        if (nickname != null) {
+            Member memberEntity = memberRepository.findByNickname(nickname).orElseThrow(
+                    () -> new IllegalArgumentException("nickname이 없습니다.")
             );
 
             UserDetailsImpl userDetails = new UserDetailsImpl(memberEntity);
 
             //Jwt 토큰 서명을 통해서 서명이 정상이면 Authentication 객체를 만들어 준다.
             Authentication authentication =
-                    new UsernamePasswordAuthenticationToken(userDetails, null,userDetails.getAuthorities());
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
             //홀더에 검증이 완료된 정보 값 넣어준다. -> 이제 controller 에서 @AuthenticationPrincipal UserDetailsImpl userDetails 로 정보를 꺼낼 수 있다.
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
@@ -74,14 +74,14 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
     /**
      * Jwt Token을 복호화 하여 이름을 얻는다.
      */
-    public String getUserNameFromJwt(String token) {
+    public String getNicknameFromJwt(String token) {
 
-        String username =
-                JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token).getClaim("username").asString();
+        String nickname =
+                JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token).getClaim("nickname").asString();
 
-        if(username != null) {
-            Member memberEntity = memberRepository.findByUsername(username).orElseThrow(
-                    () -> new IllegalArgumentException("username이 없습니다.")
+        if (nickname != null) {
+            Member memberEntity = memberRepository.findByNickname(nickname).orElseThrow(
+                    () -> new IllegalArgumentException("nickname이 없습니다.")
             );
             UserDetailsImpl userDetails = new UserDetailsImpl(memberEntity);
 
@@ -93,12 +93,12 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
     public Member getMemberFromJwt(String token) {
 
-        String username =
-                JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token).getClaim("username").asString();
+        String nickname =
+                JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token).getClaim("nickname").asString();
 
-        if(username != null) {
-            Member memberEntity = memberRepository.findByUsername(username).orElseThrow(
-                    () -> new IllegalArgumentException("username이 없습니다.")
+        if (nickname != null) {
+            Member memberEntity = memberRepository.findByNickname(nickname).orElseThrow(
+                    () -> new IllegalArgumentException("nickname이 없습니다.")
             );
             UserDetailsImpl userDetails = new UserDetailsImpl(memberEntity);
 

--- a/src/main/java/com/example/modiraa/config/jwt/JwtProperties.java
+++ b/src/main/java/com/example/modiraa/config/jwt/JwtProperties.java
@@ -1,0 +1,27 @@
+package com.example.modiraa.config.jwt;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class JwtProperties {
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.prefix}")
+    private String tokenPrefix;
+
+    @Value("${jwt.subject}")
+    private String subject;
+
+    @Value("${jwt.claim.nickname}")
+    private String nicknameClaim;
+
+    @Value("${jwt.access.expiration}")
+    private int accessExpiration;
+
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+}

--- a/src/main/java/com/example/modiraa/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/modiraa/config/jwt/JwtTokenProvider.java
@@ -24,11 +24,11 @@ public class JwtTokenProvider {
     }
 
     //토큰 발급
-    public String generate(String username, Date expiredAt){
+    public String generate(String nickname, Date expiredAt) {
         return JWT.create()
                 .withSubject("cos토큰")
                 .withExpiresAt(expiredAt)
-                .withClaim("username", username)
+                .withClaim("nickname", nickname)
                 .sign(Algorithm.HMAC512(JwtProperties.SECRET));
     }
 

--- a/src/main/java/com/example/modiraa/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/modiraa/config/jwt/JwtTokenProvider.java
@@ -7,7 +7,6 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
@@ -15,21 +14,22 @@ import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
-
+    private final JwtProperties jwtProperties;
     private final Key key;
 
-    public JwtTokenProvider(@Value("${jwt.secret-key}") String secretKey) {
-        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+    public JwtTokenProvider(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+        byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.getSecretKey());
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
     //토큰 발급
     public String generate(String nickname, Date expiredAt) {
         return JWT.create()
-                .withSubject("cos토큰")
+                .withSubject(jwtProperties.getSubject())
                 .withExpiresAt(expiredAt)
-                .withClaim("nickname", nickname)
-                .sign(Algorithm.HMAC512(JwtProperties.SECRET));
+                .withClaim(jwtProperties.getNicknameClaim(), nickname)
+                .sign(Algorithm.HMAC512(jwtProperties.getSecretKey()));
     }
 
     public String extractSubject(String accessToken) {

--- a/src/main/java/com/example/modiraa/controller/PostController.java
+++ b/src/main/java/com/example/modiraa/controller/PostController.java
@@ -2,7 +2,6 @@ package com.example.modiraa.controller;
 
 import com.example.modiraa.auth.UserDetailsImpl;
 import com.example.modiraa.dto.response.PostRequestDto;
-import com.example.modiraa.service.ChatRoomService;
 import com.example.modiraa.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,14 +14,12 @@ import org.springframework.web.bind.annotation.*;
 public class PostController {
 
     private final PostService postService;
-    private final ChatRoomService chatRoomService;
 
     // 모임 생성
     @PostMapping("/api/post")
     public ResponseEntity<String> createPost(@RequestBody PostRequestDto postRequestDto,
                                              @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        String username = userDetails.getUsername();
-        postService.createPost(username, postRequestDto, userDetails);
+        postService.createPost(postRequestDto, userDetails);
         return ResponseEntity.status(HttpStatus.CREATED).body("모임 생성 완료");
     }
 

--- a/src/main/java/com/example/modiraa/handler/StompHandler.java
+++ b/src/main/java/com/example/modiraa/handler/StompHandler.java
@@ -54,9 +54,9 @@ public class StompHandler implements ChannelInterceptor {
 
             Member member;
             if (jwtToken != null) {
-                member = memberRepository.findByNickname(jwtAuthorizationFilter.getUserNameFromJwt(jwtToken), Member.class)
-                        .orElseThrow(()->new IllegalArgumentException("member 가 존재하지 않습니다."));
-            }else {
+                member = memberRepository.findByNickname(jwtAuthorizationFilter.getNicknameFromJwt(jwtToken), Member.class)
+                        .orElseThrow(() -> new IllegalArgumentException("member 가 존재하지 않습니다."));
+            } else {
                 throw new IllegalArgumentException("유효하지 않은 token 입니다.");
             }
 

--- a/src/main/java/com/example/modiraa/repository/MemberRepository.java
+++ b/src/main/java/com/example/modiraa/repository/MemberRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByUsername(String username);
     Optional<Member> findByNickname(String nickname);
 
     <T> Optional<T> findByNickname(String nickname, Class<T> type);

--- a/src/main/java/com/example/modiraa/service/OAuthLoginService.java
+++ b/src/main/java/com/example/modiraa/service/OAuthLoginService.java
@@ -30,8 +30,8 @@ public class OAuthLoginService {
     private final MemberRepository memberRepository;
     private final AuthTokensGenerator authTokensGenerator;
     private final RequestOAuthInfoService requestOAuthInfoService;
-    private final String TOKEN_PREFIX = "Bearer ";
-    private final String HEADER_STRING = "Authorization";
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private static final String HEADER_STRING = "Authorization";
 
 
     public ResponseEntity<SocialResponseDto> login(OAuthLoginParams params) {
@@ -65,7 +65,7 @@ public class OAuthLoginService {
 
     private HttpHeaders createJwtTokenHeaders(UserDetailsImpl userDetails) {
         //JWT 토큰 발급
-        AuthTokens authTokens = authTokensGenerator.generate(userDetails.getMember().getUsername());
+        AuthTokens authTokens = authTokensGenerator.generate(userDetails.getMember().getNickname());
 
         // 응답 헤더에 JWT 토큰 추가
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/example/modiraa/service/PostService.java
+++ b/src/main/java/com/example/modiraa/service/PostService.java
@@ -29,13 +29,13 @@ public class PostService {
     private final MemberRoomQueryRepository memberRoomQueryRepository;
 
     // 모임 생성
-    public void createPost(String username, PostRequestDto postRequestDto, UserDetailsImpl userDetails) {
-        Member member = memberRepository.findByUsername(username)
+    public void createPost(PostRequestDto postRequestDto, UserDetailsImpl userDetails) {
+        Member member = memberRepository.findByNickname(userDetails.getMember().getNickname())
                 .orElseThrow(() -> new UsernameNotFoundException("다시 로그인해 주세요."));
 
         PostImage postImage = postImageRepository.findByMenu(postRequestDto.getMenu());
 
-        if(member.getPostState() == null){
+        if (member.getPostState() == null) {
             Post post = Post.builder()
                     .category(postRequestDto.getCategory())
                     .title(postRequestDto.getTitle())
@@ -58,14 +58,14 @@ public class PostService {
             member.setPostState(postRequestDto.getTitle());
             memberRepository.save(member);
 
-            ChatRoom chatRoom = new ChatRoom(userDetails.getMember(),post,post.getNumberofpeople());
+            ChatRoom chatRoom = new ChatRoom(userDetails.getMember(), post, post.getNumberofpeople());
             chatRoomRepository.save(chatRoom);
 
             post.updateRoom(chatRoom);
 
             MemberRoom memberRoom = new MemberRoom(userDetails.getMember(), chatRoom);
             memberRoomRepository.save(memberRoom);
-        } else{
+        } else {
             throw new CustomException(ErrorCode.POST_CHECK_CODE);
         }
     }
@@ -77,7 +77,7 @@ public class PostService {
 
         List<MemberRoom> memberRoomList = memberRoomQueryRepository.findByChatRoomId(post.getChatRoom().getId());
 
-        for (MemberRoom memberRoom : memberRoomList){
+        for (MemberRoom memberRoom : memberRoomList) {
             memberRoomRepository.deleteById(memberRoom.getId());
 
             Member member = memberRepository.findAllById(memberRoom.getMember().getId());


### PR DESCRIPTION
### 1. Refactor: application.yml에 spring.config.import 하는 방법으로 변경
- 직접 로드하던 방식에서 application.yml 파일에 spring.config.import를 사용하여 설정 파일을 분리하도록 변경
### 2. Fix: JWT claim 이름 변경 - username -> nickname
- JWT 토큰의 클레임(claim) 중에서 사용자의 식별자를 나타내는 부분의 이름을 "username"에서 "nickname"으로 변경
### 3. Refactor: BCryptPasswordEncoder @bean 중복 등록 제거
### 4. Refactor: WebSecurityConfigurerAdapter deprecated인해 코드 변경
- 이전에 사용하던 WebSecurityConfigurerAdapter가 deprecated 되어, 이를 대신할 수 있는 새로운 방법으로 코드를 변경
### 5. Modify: loadUserByUsername 메서드 반환타입을 UserDetailsImpl에서 UserDetails로 변경
### 6. Update: .gitignore
- JwtProperties.java 제거
- application-jwt.yml 추가
- application-oauth.yml 추가
- application-server.yml 추가
- application-spring.yml 추가
### 7. Refactor: JwtProperties 값들을 yml 파일로 관리하도록 변경
- JwtProperties 클래스에서 사용되는 값들을 .yml 파일에 정의하여 하드 코딩을 제거하고 외부에서 설정할 수 있도록 변경
- @Value 어노테이션을 사용하여 yml 파일의 값들을 주입받도록 수정