### PR TITLE
Rating, Post, MemberRoom, Member, ChatRoom, ChatMessage Repository에 대한 테스트 추가

### DIFF
--- a/src/test/java/com/example/modiraa/config/TestQuerydslConfig.java
+++ b/src/test/java/com/example/modiraa/config/TestQuerydslConfig.java
@@ -1,0 +1,25 @@
+package com.example.modiraa.config;
+
+import com.example.modiraa.repository.ChatMessageQueryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
+
+@TestConfiguration
+public class TestQuerydslConfig {
+    @Autowired
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+    @Bean
+    public ChatMessageQueryRepository chatMessageQueryRepository() {
+        return new ChatMessageQueryRepository(jpaQueryFactory());
+    }
+}

--- a/src/test/java/com/example/modiraa/repository/ChatMessageQueryRepositoryTest.java
+++ b/src/test/java/com/example/modiraa/repository/ChatMessageQueryRepositoryTest.java
@@ -1,0 +1,95 @@
+package com.example.modiraa.repository;
+
+import com.example.modiraa.config.TestQuerydslConfig;
+import com.example.modiraa.dto.request.oauth.OAuthProvider;
+import com.example.modiraa.enums.GenderType;
+import com.example.modiraa.model.ChatMessage;
+import com.example.modiraa.model.ChatRoom;
+import com.example.modiraa.model.Member;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({TestQuerydslConfig.class})
+class ChatMessageQueryRepositoryTest {
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ChatMessageQueryRepository repository;
+
+    @BeforeEach
+    public void before() {
+        Member member1 = new Member("profileImage1", "nickname1", 20,
+                GenderType.MALE, "address1", "oAuthId1", OAuthProvider.KAKAO);
+        Member member2 = new Member("profileImage2", "nickname2", 30,
+                GenderType.FEMALE, "address2", "oAuthId2", OAuthProvider.NAVER);
+
+        ChatRoom chatRoom1 = new ChatRoom(5);
+        ChatRoom chatRoom2 = new ChatRoom(6);
+
+        ChatMessage chatMessage1 = new ChatMessage(ChatMessage.MessageType.ENTER,
+                chatRoom1.getRoomCode(), member1, "message1");
+        ChatMessage chatMessage2 = new ChatMessage(ChatMessage.MessageType.TALK,
+                chatRoom1.getRoomCode(), member1, "message2");
+        ChatMessage chatMessage3 = new ChatMessage(ChatMessage.MessageType.TALK,
+                chatRoom1.getRoomCode(), member1, "message3");
+        ChatMessage chatMessage4 = new ChatMessage(ChatMessage.MessageType.TALK,
+                chatRoom2.getRoomCode(), member2, "message4");
+        ChatMessage chatMessage5 = new ChatMessage(ChatMessage.MessageType.TALK,
+                chatRoom2.getRoomCode(), member2, "message5");
+        ChatMessage chatMessage6 = new ChatMessage(ChatMessage.MessageType.TALK,
+                chatRoom2.getRoomCode(), member2, "message6");
+
+        em.persist(member1);
+        em.persist(member2);
+        em.persist(chatRoom1);
+        em.persist(chatRoom2);
+        em.persist(chatMessage1);
+        em.persist(chatMessage2);
+        em.persist(chatMessage3);
+        em.persist(chatMessage4);
+        em.persist(chatMessage5);
+        em.persist(chatMessage6);
+    }
+
+    @AfterEach
+    public void cleanupTestData() {
+        em.clear(); // 영속성 컨텍스트 초기화
+    }
+
+    @Test
+    @DisplayName("채팅방의 최근 메세지 150개를 페이징하여 가져오기")
+    void findByRoomCodeOrderByIdDesc() {
+        // Given
+        Pageable pageable = PageRequest.of(0, 150, Sort.by(Sort.Direction.DESC, "id"));
+
+        ChatRoom chatRoom1 = em.find(ChatRoom.class, 1L);
+        ChatRoom chatRoom2 = em.find(ChatRoom.class, 2L);
+
+        // When
+        Page<ChatMessage> result1 = repository.findByRoomCodeOrderByIdDesc(chatRoom1.getRoomCode(), pageable);
+        Page<ChatMessage> result2 = repository.findByRoomCodeOrderByIdDesc(chatRoom2.getRoomCode(), pageable);
+
+        // Then
+        assertThat(result1.getContent())
+                .extracting("message")
+                .containsExactly("message3", "message2", "message1");
+        assertThat(result2.getContent())
+                .extracting("message")
+                .containsExactly("message6", "message5", "message4");
+    }
+}

--- a/src/test/java/com/example/modiraa/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/example/modiraa/repository/ChatRoomRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.example.modiraa.repository;
+
+import com.example.modiraa.config.TestQuerydslConfig;
+import com.example.modiraa.model.ChatRoom;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({TestQuerydslConfig.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD) // EntityManager 초기화
+class ChatRoomRepositoryTest {
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ChatRoomRepository repository;
+
+
+    @BeforeEach
+    public void before() {
+        ChatRoom chatRoom1 = new ChatRoom(3);
+        ChatRoom chatRoom2 = new ChatRoom(4);
+        ChatRoom chatRoom3 = new ChatRoom(5);
+
+        em.persist(chatRoom1);
+        em.persist(chatRoom2);
+        em.persist(chatRoom3);
+    }
+
+    @AfterEach
+    public void cleanupTestData() {
+        em.clear(); // 영속성 컨텍스트 초기화
+    }
+
+
+    @Test
+    @DisplayName("RoomCode로 채팅방 조회")
+    void testFindByRoomCode() {
+        // Given
+        ChatRoom chatRoom1 = em.find(ChatRoom.class, 1L);
+        ChatRoom chatRoom2 = em.find(ChatRoom.class, 2L);
+        ChatRoom chatRoom3 = em.find(ChatRoom.class, 3L);
+
+        // When
+        ChatRoom result1 = repository.findByRoomCode(chatRoom1.getRoomCode()).get();
+        ChatRoom result2 = repository.findByRoomCode(chatRoom2.getRoomCode()).get();
+        ChatRoom result3 = repository.findByRoomCode(chatRoom3.getRoomCode()).get();
+
+        // Then
+        assertThat(result1).isEqualTo(chatRoom1);
+        assertThat(result2).isEqualTo(chatRoom2);
+        assertThat(result3).isEqualTo(chatRoom3);
+
+        assertThat(result1.getMaxParticipant()).isEqualTo(3);
+        assertThat(result2.getMaxParticipant()).isEqualTo(4);
+        assertThat(result3.getMaxParticipant()).isEqualTo(5);
+
+        assertThat(result1.getRoomCode()).isEqualTo(chatRoom1.getRoomCode());
+        assertThat(result2.getRoomCode()).isEqualTo(chatRoom2.getRoomCode());
+        assertThat(result3.getRoomCode()).isEqualTo(chatRoom3.getRoomCode());
+    }
+}

--- a/src/test/java/com/example/modiraa/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/example/modiraa/repository/MemberRepositoryTest.java
@@ -1,0 +1,118 @@
+package com.example.modiraa.repository;
+
+import com.example.modiraa.config.TestQuerydslConfig;
+import com.example.modiraa.dto.request.oauth.OAuthProvider;
+import com.example.modiraa.enums.GenderType;
+import com.example.modiraa.model.Member;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({TestQuerydslConfig.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class MemberRepositoryTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private MemberRepository repository;
+
+    @BeforeEach //테스트 실행 전 데이터를 넣는 작업 진행
+    public void before() {
+        Member member1 = new Member("profileImage1", "nickname1", 20,
+                GenderType.MALE, "address1", "oAuthId1", OAuthProvider.KAKAO);
+        Member member2 = new Member("profileImage2", "nickname2", 30,
+                GenderType.MALE, "address2", "oAuthId2", OAuthProvider.KAKAO);
+        Member member3 = new Member("profileImage3", "nickname3", 20,
+                GenderType.FEMALE, "address3", "oAuthId3", OAuthProvider.NAVER);
+        Member member4 = new Member("profileImage4", "nickname4", 20,
+                GenderType.FEMALE, "address4", "oAuthId4", OAuthProvider.NAVER);
+
+        em.persist(member1);
+        em.persist(member2);
+        em.persist(member3);
+        em.persist(member4);
+    }
+
+    @AfterEach
+    public void cleanupTestData() {
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("Optional<Member> 닉네임으로 멤버 찾기")
+    void findByNickname() {
+        // Given
+        String nickname1 = "nickname1";
+        String nickname2 = "nickname2";
+        String nickname3 = "nickname3";
+        String nickname4 = "nickname4";
+
+        // When
+        Member result1 = repository.findByNickname(nickname1).get();
+        Member result2 = repository.findByNickname(nickname2).get();
+        Member result3 = repository.findByNickname(nickname3).get();
+        Member result4 = repository.findByNickname(nickname4).get();
+
+        // Then
+        assertThat(result1.getNickname()).isEqualTo(nickname1);
+        assertThat(result2.getNickname()).isEqualTo(nickname2);
+        assertThat(result3.getNickname()).isEqualTo(nickname3);
+        assertThat(result4.getNickname()).isEqualTo(nickname4);
+    }
+
+    @Test
+    @DisplayName("<T> Optional<T> 닉네임으로 멤버 찾기")
+    void testFindByNickname() {
+        // Given
+        String nickname1 = "nickname1";
+        String nickname2 = "nickname2";
+        String nickname3 = "nickname3";
+        String nickname4 = "nickname4";
+
+        // When
+        Member result1 = repository.findByNickname(nickname1, Member.class).get();
+        Member result2 = repository.findByNickname(nickname2, Member.class).get();
+        Member result3 = repository.findByNickname(nickname3, Member.class).get();
+        Member result4 = repository.findByNickname(nickname4, Member.class).get();
+
+        // Then
+        assertThat(result1.getNickname()).isEqualTo(nickname1);
+        assertThat(result2.getNickname()).isEqualTo(nickname2);
+        assertThat(result3.getNickname()).isEqualTo(nickname3);
+        assertThat(result4.getNickname()).isEqualTo(nickname4);
+    }
+
+    @Test
+    @DisplayName("OAuthId로 멤버 찾기")
+    void testFindByOAuthId() {
+        // Given
+        String oAuthId1 = "oAuthId1";
+        String oAuthId2 = "oAuthId2";
+        String oAuthId3 = "oAuthId3";
+        String oAuthId4 = "oAuthId4";
+
+        // When
+        Member result1 = repository.findByOAuthId(oAuthId1).get();
+        Member result2 = repository.findByOAuthId(oAuthId2).get();
+        Member result3 = repository.findByOAuthId(oAuthId3).get();
+        Member result4 = repository.findByOAuthId(oAuthId4).get();
+
+        // Then
+        assertThat(result1.getOAuthId()).isEqualTo(oAuthId1);
+        assertThat(result2.getOAuthId()).isEqualTo(oAuthId2);
+        assertThat(result3.getOAuthId()).isEqualTo(oAuthId3);
+        assertThat(result4.getOAuthId()).isEqualTo(oAuthId4);
+    }
+}

--- a/src/test/java/com/example/modiraa/repository/MemberRoomRepositoryTest.java
+++ b/src/test/java/com/example/modiraa/repository/MemberRoomRepositoryTest.java
@@ -1,0 +1,183 @@
+package com.example.modiraa.repository;
+
+import com.example.modiraa.config.TestQuerydslConfig;
+import com.example.modiraa.dto.request.oauth.OAuthProvider;
+import com.example.modiraa.dto.response.JoinedMembersResponse;
+import com.example.modiraa.dto.response.JoinedPostsResponse;
+import com.example.modiraa.enums.GenderType;
+import com.example.modiraa.model.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({TestQuerydslConfig.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class MemberRoomRepositoryTest {
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private MemberRoomRepository repository;
+
+    @BeforeEach
+    public void before() {
+        Member member1 = new Member("profileImage1", "nickname1", 20,
+                GenderType.MALE, "address1", "oAuthId1", OAuthProvider.KAKAO);
+        Member member2 = new Member("profileImage2", "nickname2", 30,
+                GenderType.MALE, "address2", "oAuthId2", OAuthProvider.KAKAO);
+        Member member3 = new Member("profileImage3", "nickname3", 20,
+                GenderType.FEMALE, "address3", "oAuthId3", OAuthProvider.NAVER);
+        Member member4 = new Member("profileImage4", "nickname4", 20,
+                GenderType.FEMALE, "address4", "oAuthId4", OAuthProvider.NAVER);
+
+        PostImage postImage1 = new PostImage("menu1", "imageUrl1");
+        PostImage postImage2 = new PostImage("menu2", "imageUrl2");
+
+        ChatRoom chatRoom1 = new ChatRoom(3);
+        ChatRoom chatRoom2 = new ChatRoom(4);
+        ChatRoom chatRoom3 = new ChatRoom(5);
+
+        Post post1 = new Post("골든벨", "title1", "contents1", "서울 성동구", 1.1, 1.1,
+                LocalDate.now(), LocalTime.now(), GenderType.MALE, 10, 20, member1, postImage1, chatRoom1);
+        Post post2 = new Post("N빵", "title2", "contents2", "서울 용산구", 2.2, 2.2,
+                LocalDate.now(), LocalTime.now(), GenderType.MALE, 20, 30, member2, postImage2, chatRoom2);
+        Post post3 = new Post("N빵", "title3", "contents3", "서울 동대문구", 3.3, 3.3,
+                LocalDate.now(), LocalTime.now(), GenderType.FEMALE, 30, 40, member3, postImage2, chatRoom3);
+
+        MemberRoom memberRoom1 = new MemberRoom(member2, chatRoom1);
+        MemberRoom memberRoom2 = new MemberRoom(member3, chatRoom1);
+        MemberRoom memberRoom3 = new MemberRoom(member4, chatRoom1);
+        MemberRoom memberRoom4 = new MemberRoom(member1, chatRoom2);
+        MemberRoom memberRoom5 = new MemberRoom(member3, chatRoom2);
+        MemberRoom memberRoom6 = new MemberRoom(member1, chatRoom3);
+
+        em.persist(member1);
+        em.persist(member2);
+        em.persist(member3);
+        em.persist(member4);
+        em.persist(postImage1);
+        em.persist(postImage2);
+        em.persist(chatRoom1);
+        em.persist(chatRoom2);
+        em.persist(chatRoom3);
+        em.persist(post1);
+        em.persist(post2);
+        em.persist(post3);
+        em.persist(memberRoom1);
+        em.persist(memberRoom2);
+        em.persist(memberRoom3);
+        em.persist(memberRoom4);
+        em.persist(memberRoom5);
+        em.persist(memberRoom6);
+    }
+
+    @AfterEach
+    public void cleanupTestData() {
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("ChatRoom, Member로 MemberRoom 조회")
+    void testFindByChatRoomAndMember() {
+        ChatRoom chatRoom1 = em.find(ChatRoom.class, 1L);
+        Member member2 = em.find(Member.class, 2L);
+        MemberRoom memberRoom1 = em.find(MemberRoom.class, 1L);
+
+        // When
+        MemberRoom result = repository.findByChatRoomAndMember(chatRoom1, member2).get();
+
+        // Then
+        assertThat(result).isEqualTo(memberRoom1);
+    }
+
+    @Test
+    @DisplayName("ChatRoomId로 MemberRoom 조회")
+    void testFindByChatRoomId() {
+        // Given
+        ChatRoom chatRoom1 = em.find(ChatRoom.class, 1L);
+        MemberRoom memberRoom1 = em.find(MemberRoom.class, 1L);
+        MemberRoom memberRoom2 = em.find(MemberRoom.class, 2L);
+        MemberRoom memberRoom3 = em.find(MemberRoom.class, 3L);
+
+        // When
+        List<MemberRoom> result = repository.findByChatRoomId(chatRoom1.getId());
+
+        // Then
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result).containsExactly(memberRoom1, memberRoom2, memberRoom3);
+    }
+
+    @Test
+    @DisplayName("멤버가 가장 최근에 참여한(작성한) MemberRoom 조회")
+    void testFindTopByMemberOrderByIdDesc() {
+        // Given
+        Member member1 = em.find(Member.class, 1L);
+        MemberRoom memberRoom6 = em.find(MemberRoom.class, 6L);
+
+        // When
+        MemberRoom result = repository.findTopByMemberOrderByIdDesc(member1).get();
+
+        // Then
+        assertThat(result).isEqualTo(memberRoom6);
+    }
+
+    @Test
+    @DisplayName("ChatRoomId, MemberId로 MemberRoom 조회")
+    void testFindByChatRoomIdAndMemberId() {
+        // Given
+        ChatRoom chatRoom1 = em.find(ChatRoom.class, 1L);
+        Member member2 = em.find(Member.class, 2L);
+        MemberRoom memberRoom1 = em.find(MemberRoom.class, 1L);
+
+        // When
+        MemberRoom result = repository.findByChatRoomIdAndMemberId(chatRoom1.getId(), member2.getId()).get();
+
+        // Then
+        assertThat(result).isEqualTo(memberRoom1);
+    }
+
+    @Test
+    @DisplayName("멤버가 참여한 모임 리스트 조회")
+    void testFindJoinedPostsByMember() {
+        // Given
+        Member member1 = em.find(Member.class, 1L);
+
+        // When
+        List<JoinedPostsResponse> result = repository.findJoinedPostsByMember(member1.getId());
+
+        // Then
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result)
+                .extracting("title")
+                .containsExactly("title3", "title2");
+    }
+
+    @Test
+    @DisplayName("참여한 멤버 정보 리스트 조회")
+    void testFindJoinedMembersByMemberRoom() {
+        // Given
+        ChatRoom chatRoom1 = em.find(ChatRoom.class, 1L);
+
+        // When
+        List<JoinedMembersResponse> result = repository.findJoinedMembersByMemberRoom(chatRoom1.getId());
+
+        // Then
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result)
+                .extracting("nickname")
+                .containsExactly("nickname2", "nickname3", "nickname4");
+    }
+}

--- a/src/test/java/com/example/modiraa/repository/PostRepositoryTest.java
+++ b/src/test/java/com/example/modiraa/repository/PostRepositoryTest.java
@@ -1,0 +1,305 @@
+package com.example.modiraa.repository;
+
+import com.example.modiraa.config.TestQuerydslConfig;
+import com.example.modiraa.dto.request.oauth.OAuthProvider;
+import com.example.modiraa.dto.response.MyPostsResponse;
+import com.example.modiraa.enums.GenderType;
+import com.example.modiraa.model.ChatRoom;
+import com.example.modiraa.model.Member;
+import com.example.modiraa.model.Post;
+import com.example.modiraa.model.PostImage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.annotation.DirtiesContext;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({TestQuerydslConfig.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class PostRepositoryTest {
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private PostRepository repository;
+
+
+    @BeforeEach
+    public void before() {
+        Member member1 = new Member("profileImage1", "nickname1", 20,
+                GenderType.MALE, "address1", "oAuthId1", OAuthProvider.KAKAO);
+        Member member2 = new Member("profileImage2", "nickname2", 30,
+                GenderType.MALE, "address2", "oAuthId2", OAuthProvider.KAKAO);
+        Member member3 = new Member("profileImage3", "nickname3", 20,
+                GenderType.FEMALE, "address3", "oAuthId3", OAuthProvider.NAVER);
+
+        PostImage postImage1 = new PostImage("menu1", "imageUrl1");
+        PostImage postImage2 = new PostImage("menu2", "imageUrl2");
+
+        ChatRoom chatRoom1 = new ChatRoom(10);
+        ChatRoom chatRoom2 = new ChatRoom(20);
+        ChatRoom chatRoom3 = new ChatRoom(30);
+
+        Post post1 = new Post("골든벨", "title1", "contents1", "서울 성동구", 1.1, 1.1,
+                LocalDate.now(), LocalTime.now(), GenderType.MALE, 10, 20, member1, postImage1, chatRoom1);
+        Post post2 = new Post("N빵", "title2", "contents2", "서울 용산구", 2.2, 2.2,
+                LocalDate.now(), LocalTime.now(), GenderType.MALE, 20, 30, member1, postImage2, chatRoom2);
+        Post post3 = new Post("N빵", "title3", "contents3", "서울 동대문구", 3.3, 3.3,
+                LocalDate.now(), LocalTime.now(), GenderType.FEMALE, 30, 40, member3, postImage2, chatRoom3);
+
+        em.persist(member1);
+        em.persist(member2);
+        em.persist(member3);
+        em.persist(postImage1);
+        em.persist(postImage2);
+        em.persist(chatRoom1);
+        em.persist(chatRoom2);
+        em.persist(chatRoom3);
+        em.persist(post1);
+        em.persist(post2);
+        em.persist(post3);
+    }
+
+    @AfterEach
+    public void cleanupTestData() {
+        em.clear();
+    }
+
+
+    @Test
+    @DisplayName("Post Save")
+    public void testFestPostSave() {
+        // Given
+        Member member1 = em.find(Member.class, 1L);
+        PostImage postImage1 = em.find(PostImage.class, 1L);
+        ChatRoom chatRoom1 = em.find(ChatRoom.class, 1L);
+        Post post1 = new Post("category1", "title1", "contents1", "address1", 1.1, 1.1,
+                LocalDate.now(), LocalTime.now(), GenderType.MALE, 10, 20, member1, postImage1, chatRoom1);
+
+        // When
+        repository.save(post1);
+
+        // Then
+        Post result = repository.findById(post1.getId()).get();
+        assertThat(result).isEqualTo(post1);
+    }
+
+
+    @Test
+    @DisplayName("ChatRoom Id로 Post 조회")
+    public void testFindByChatRoomId() {
+        // Given
+        Member member1 = em.find(Member.class, 1L);
+        PostImage postImage1 = em.find(PostImage.class, 1L);
+        ChatRoom chatRoom1 = em.find(ChatRoom.class, 1L);
+        Post post1 = em.find(Post.class, 1L);
+
+        Long chatRoomId = chatRoom1.getId();
+
+        // When
+        Post result = repository.findByChatRoomId(chatRoomId).get();
+
+        // Then
+        assertThat(result).isEqualTo(post1);
+        assertThat(result.getId()).isEqualTo(post1.getId());
+        assertThat(result.getOwner().getId()).isEqualTo(member1.getId());
+        assertThat(result.getChatRoom().getId()).isEqualTo(chatRoom1.getId());
+        assertThat(result.getPostImage().getId()).isEqualTo(postImage1.getId());
+    }
+
+    @Test
+    @DisplayName("검색어에 따른 Post 조회 - 검색어[메뉴]")
+    public void testFindBySearchKeywordAndAddress_KeywordMenu() {
+        // Given
+        Long lastId = 100L;
+        String address = "서울";
+        String keywordMenu = "menu1";
+        Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "id"));
+
+        // When
+        Page<Post> resultMenu = repository.findBySearchKeywordAndAddress(lastId, address, keywordMenu, pageable);
+
+        // Then
+        assertThat(resultMenu.getSize()).isEqualTo(8);
+        assertThat(resultMenu.getContent().size()).isEqualTo(1);
+        assertThat(resultMenu.getContent().get(0).getPostImage().getMenu()).isEqualTo("menu1");
+    }
+
+    @Test
+    @DisplayName("검색어에 따른 Post 조회 - 검색어[제목]")
+    public void testFindBySearchKeywordAndAddress_KeywordTitle() {
+        // Given
+        Long lastId = 100L;
+        String address = "서울";
+        String keywordTitle = "title";
+        Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "id"));
+
+        // When
+        Page<Post> resultTitle = repository.findBySearchKeywordAndAddress(lastId, address, keywordTitle, pageable);
+
+        // Then
+        assertThat(resultTitle.getContent().size()).isEqualTo(3);
+        assertThat(resultTitle.getContent())
+                .extracting("title")
+                .containsExactly("title3", "title2", "title1");
+    }
+
+    @Test
+    @DisplayName("검색어에 따른 Post 조회 - 검색어[내용]")
+    public void testFindBySearchKeywordAndAddress_KeywordContents() {
+        // Given
+        Long lastId = 100L;
+        String address = "서울";
+        String keywordContents = "content";
+        Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "id"));
+
+        // When
+        Page<Post> resultContents = repository.findBySearchKeywordAndAddress(lastId, address, keywordContents, pageable);
+
+        // Then
+        assertThat(resultContents.getContent().size()).isEqualTo(3);
+        assertThat(resultContents.getContent())
+                .extracting("contents")
+                .containsExactly("contents3", "contents2", "contents1");
+    }
+
+    @Test
+    @DisplayName("lastId 및 카테고리에 따른 Post 조회")
+    public void testFindByIdLessThanAndCategory() {
+        // Given
+        Long lastId = 100L;
+        String goldenBellCategory = "골든벨";
+        String dutchPayCategory = "N빵";
+        Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "id"));
+
+        // When
+        Page<Post> goldenBell = repository.findByIdLessThanAndCategory(lastId, goldenBellCategory, pageable);
+        Page<Post> DutchPay = repository.findByIdLessThanAndCategory(lastId, dutchPayCategory, pageable);
+
+        // Then
+        assertThat(goldenBell.getContent().size()).isEqualTo(1);
+        assertThat(goldenBell.getContent())
+                .extracting("title")
+                .containsExactly("title1");
+
+        assertThat(DutchPay.getContent().size()).isEqualTo(2);
+        assertThat(DutchPay.getContent())
+                .extracting("title")
+                .containsExactly("title3", "title2");
+    }
+
+    @Test
+    @DisplayName("모든 Post 조회")
+    public void testFindAllPosts() {
+        // Given
+        Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "id"));
+
+        // When
+        Page<Post> result = repository.findAllPosts(pageable);
+
+        // Then
+        assertThat(result.getSize()).isEqualTo(8);
+
+        assertThat(result.getContent().size()).isEqualTo(3);
+        assertThat(result.getContent())
+                .extracting("title")
+                .containsExactly("title3", "title2", "title1");
+    }
+
+    @Test
+    @DisplayName("카테고리별 Post 조회")
+    public void testFindByCategory() {
+        // Given
+        String goldenBellCategory = "골든벨";
+        String dutchPayCategory = "N빵";
+        Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "id"));
+
+        // When
+        Page<Post> goldenBell = repository.findByCategory(goldenBellCategory, pageable);
+        Page<Post> dutchPay = repository.findByCategory(dutchPayCategory, pageable);
+
+        // Then
+        assertThat(goldenBell.getSize()).isEqualTo(8);
+
+        assertThat(goldenBell.getContent().size()).isEqualTo(1);
+        assertThat(goldenBell.getContent())
+                .extracting("title")
+                .containsExactly("title1");
+
+        assertThat(dutchPay.getContent().size()).isEqualTo(2);
+        assertThat(dutchPay.getContent())
+                .extracting("title")
+                .containsExactly("title3", "title2");
+    }
+
+    @Test
+    @DisplayName("로그인 회원 주소에 따른 모든 Post 조회")
+    public void testFindAllByAddress() {
+        // Given
+        String memberAddress = "서울";
+        Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "id"));
+
+        // When
+        Page<Post> result = repository.findAllByAddress(memberAddress, pageable);
+
+        // Then
+        assertThat(result.getSize()).isEqualTo(8);
+
+        assertThat(result.getContent().size()).isEqualTo(3);
+        assertThat(result.getContent())
+                .extracting("title")
+                .containsExactly("title3", "title2", "title1");
+    }
+
+    @Test
+    @DisplayName("로그인 회원 주소 및 카테고리에 따른 Post 조회")
+    public void testFindByAddressAndCategory() {
+        // Given
+        String memberAddress = "서울";
+        String goldenBellCategory = "골든벨";
+        Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "id"));
+
+        // When
+        Page<Post> result = repository.findByAddressAndCategory(memberAddress, goldenBellCategory, pageable);
+
+        // Then
+        assertThat(result.getSize()).isEqualTo(8);
+
+        assertThat(result.getContent().size()).isEqualTo(1);
+        assertThat(result.getContent())
+                .extracting("title")
+                .containsExactly("title1");
+
+    }
+
+    @Test
+    @DisplayName("본인이 작성한 Post 내림차순으로 조회")
+    public void testFindMyPostsByMemberOrderByDesc() {
+        // Given
+        Long memberId = 1L;
+
+        // When
+        List<MyPostsResponse> result = repository.findMyPostsByMemberOrderByDesc(memberId);
+
+        // Then
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result)
+                .extracting("title")
+                .containsExactly("title2", "title1");
+    }
+}

--- a/src/test/java/com/example/modiraa/repository/RatingRepositoryTest.java
+++ b/src/test/java/com/example/modiraa/repository/RatingRepositoryTest.java
@@ -1,0 +1,183 @@
+package com.example.modiraa.repository;
+
+import com.example.modiraa.config.TestQuerydslConfig;
+import com.example.modiraa.dto.request.oauth.OAuthProvider;
+import com.example.modiraa.enums.GenderType;
+import com.example.modiraa.enums.RatingType;
+import com.example.modiraa.model.Member;
+import com.example.modiraa.model.Rating;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({TestQuerydslConfig.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class RatingRepositoryTest {
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    RatingRepository repository;
+
+
+    @BeforeEach
+    public void before() {
+        Member member1 = new Member("profileImage1", "nickname1", 20,
+                GenderType.MALE, "address1", "oAuthId1", OAuthProvider.KAKAO);
+        Member member2 = new Member("profileImage2", "nickname2", 30,
+                GenderType.MALE, "address2", "oAuthId2", OAuthProvider.KAKAO);
+        Member member3 = new Member("profileImage3", "nickname3", 20,
+                GenderType.FEMALE, "address3", "oAuthId3", OAuthProvider.NAVER);
+        Member member4 = new Member("profileImage4", "nickname4", 20,
+                GenderType.FEMALE, "address4", "oAuthId4", OAuthProvider.NAVER);
+        Member member5 = new Member("profileImage4", "nickname4", 20,
+                GenderType.FEMALE, "address4", "oAuthId4", OAuthProvider.NAVER);
+
+        Rating rating1 = new Rating(RatingType.LIKE, member2, member1);
+        Rating rating2 = new Rating(RatingType.LIKE, member3, member1);
+        Rating rating3 = new Rating(RatingType.LIKE, member4, member1);
+        Rating rating4 = new Rating(RatingType.LIKE, member1, member2);
+        Rating rating5 = new Rating(RatingType.LIKE, member3, member2);
+        Rating rating6 = new Rating(RatingType.DISLIKE, member4, member2);
+        Rating rating7 = new Rating(RatingType.LIKE, member1, member3);
+        Rating rating8 = new Rating(RatingType.DISLIKE, member2, member3);
+        Rating rating9 = new Rating(RatingType.DISLIKE, member4, member3);
+        Rating rating10 = new Rating(RatingType.DISLIKE, member1, member4);
+        Rating rating11 = new Rating(RatingType.DISLIKE, member2, member4);
+        Rating rating12 = new Rating(RatingType.DISLIKE, member3, member4);
+
+        em.persist(member1);
+        em.persist(member2);
+        em.persist(member3);
+        em.persist(member4);
+        em.persist(member5);
+        em.persist(rating1);
+        em.persist(rating2);
+        em.persist(rating3);
+        em.persist(rating4);
+        em.persist(rating5);
+        em.persist(rating6);
+        em.persist(rating7);
+        em.persist(rating8);
+        em.persist(rating9);
+        em.persist(rating10);
+        em.persist(rating11);
+        em.persist(rating12);
+    }
+
+    @AfterEach
+    public void cleanupTestData() {
+        em.clear();
+    }
+
+
+    @Test
+    @DisplayName("평가 하는 멤버, 평가 받는 멤버로 조회")
+    void testFindByGiverAndReceiver() {
+        Member member1 = em.find(Member.class, 1L);
+        Member member2 = em.find(Member.class, 2L);
+        Member member3 = em.find(Member.class, 3L);
+
+        Rating rating1 = em.find(Rating.class, 1L);
+        Rating rating2 = em.find(Rating.class, 2L);
+
+        Rating result1 = repository.findByGiverAndReceiver(member2, member1).orElse(null);
+        Rating result2 = repository.findByGiverAndReceiver(member3, member1).orElse(null);
+
+        assertThat(result1).isEqualTo(rating1);
+        assertThat(result2).isEqualTo(rating2);
+    }
+
+    @Test
+    @DisplayName("평가 유형, 보내는 멤버, 받는 멤버로 조회")
+    void testFindByRatingTypeAndGiverAndReceiver() {
+        Member member1 = em.find(Member.class, 1L);
+        Member member2 = em.find(Member.class, 2L);
+        Member member4 = em.find(Member.class, 4L);
+
+        Rating rating1 = em.find(Rating.class, 1L);
+        Rating rating6 = em.find(Rating.class, 6L);
+
+        Rating result1 = repository.findByRatingTypeAndGiverAndReceiver(RatingType.LIKE, member2, member1).orElse(null);
+        Rating result2 = repository.findByRatingTypeAndGiverAndReceiver(RatingType.DISLIKE, member4, member2).orElse(null);
+
+        assertThat(result1).isEqualTo(rating1);
+        assertThat(result2).isEqualTo(rating6);
+    }
+
+    @Test
+    @DisplayName("좋아요 받은 수 확인")
+    void testCountLikesForReceiver() {
+        Member member1 = em.find(Member.class, 1L);
+        Member member2 = em.find(Member.class, 2L);
+        Member member3 = em.find(Member.class, 3L);
+        Member member4 = em.find(Member.class, 4L);
+        Member member5 = em.find(Member.class, 5L);
+
+        Long likeCount1 = repository.countLikesForReceiver(member1.getId());
+        Long likeCount2 = repository.countLikesForReceiver(member2.getId());
+        Long likeCount3 = repository.countLikesForReceiver(member3.getId());
+        Long likeCount4 = repository.countLikesForReceiver(member4.getId());
+        Long likeCount5 = repository.countLikesForReceiver(member5.getId());
+
+        assertThat(likeCount1).isEqualTo(3);
+        assertThat(likeCount2).isEqualTo(2);
+        assertThat(likeCount3).isEqualTo(1);
+        assertThat(likeCount4).isEqualTo(0);
+        assertThat(likeCount5).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("싫어요 받은 수 확인")
+    void testCountDislikesForReceiver() {
+        Member member1 = em.find(Member.class, 1L);
+        Member member2 = em.find(Member.class, 2L);
+        Member member3 = em.find(Member.class, 3L);
+        Member member4 = em.find(Member.class, 4L);
+        Member member5 = em.find(Member.class, 5L);
+
+        Long likeCount1 = repository.countDislikesForReceiver(member1.getId());
+        Long likeCount2 = repository.countDislikesForReceiver(member2.getId());
+        Long likeCount3 = repository.countDislikesForReceiver(member3.getId());
+        Long likeCount4 = repository.countDislikesForReceiver(member4.getId());
+        Long likeCount5 = repository.countDislikesForReceiver(member5.getId());
+
+        assertThat(likeCount1).isEqualTo(0);
+        assertThat(likeCount2).isEqualTo(1);
+        assertThat(likeCount3).isEqualTo(2);
+        assertThat(likeCount4).isEqualTo(3);
+        assertThat(likeCount5).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("[좋아요 받은 수] - [싫어요 받은 수] 확인")
+    void testCalculateScore() {
+        Member member1 = em.find(Member.class, 1L);
+        Member member2 = em.find(Member.class, 2L);
+        Member member3 = em.find(Member.class, 3L);
+        Member member4 = em.find(Member.class, 4L);
+        Member member5 = em.find(Member.class, 5L);
+
+        Long score1 = repository.calculateScore(member1.getId());
+        Long score2 = repository.calculateScore(member2.getId());
+        Long score3 = repository.calculateScore(member3.getId());
+        Long score4 = repository.calculateScore(member4.getId());
+        Long score5 = repository.calculateScore(member5.getId());
+
+        assertThat(score1).isEqualTo(3);
+        assertThat(score2).isEqualTo(1);
+        assertThat(score3).isEqualTo(-1);
+        assertThat(score4).isEqualTo(-3);
+        assertThat(score5).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
### 1. Test: ChatMessageQueryRepositoryTest 추가
- 채팅방의 최근 메세지 150개를 페이징하여 가져오기

### 2. Test: ChatRoomRepositoryTest 추가
- RoomCode로 채팅방 조회

### 3. Test: MemberRepositoryTest 추가
- Optional<Member> 닉네임으로 멤버 찾기
- <T> Optional<T> 닉네임으로 멤버 찾기
- OAuthId로 멤버 찾기

### 4. Test: MemberRoomRepositoryTest 추가
- ChatRoom, Member로 MemberRoom 조회
- ChatRoomId로 MemberRoom 조회
- 멤버가 가장 최근에 참여한(작성한) MemberRoom 조회
- ChatRoomId, MemberId로 MemberRoom 조회
- 멤버가 참여한 모임 리스트 조회
- 참여한 멤버 정보 리스트 조회

### 5. Test: PostRepositoryTest 추가
- Post Save
- ChatRoom Id로 Post 조회
- 검색어에 따른 Post 조회 - 검색어[메뉴]
- 검색어에 따른 Post 조회 - 검색어[제목]
- 검색어에 따른 Post 조회 - 검색어[내용]
- lastId 및 카테고리에 따른 Post 조회
- 모든 Post 조회
- 카테고리별 Post 조회
- 로그인 회원 주소에 따른 모든 Post 조회
- 로그인 회원 주소 및 카테고리에 따른 Post 조회
- 본인이 작성한 Post 내림차순으로 조회

### 6. Test: RatingRepositoryTest 추가
- 평가 하는 멤버, 평가 받는 멤버로 조회
- 평가 유형, 보내는 멤버, 받는 멤버로 조회
- 좋아요 받은 수 확인
- 싫어요 받은 수 확인
- [좋아요 받은 수] - [싫어요 받은 수] 확인