### PR TITLE
refactor

### DIFF
--- a/src/main/java/com/example/modiraa/controller/AuthController.java
+++ b/src/main/java/com/example/modiraa/controller/AuthController.java
@@ -1,21 +1,28 @@
 package com.example.modiraa.controller;
 
+import com.example.modiraa.dto.request.AdditionalInfoRequest;
 import com.example.modiraa.dto.request.oauth.KakaoLoginParams;
 import com.example.modiraa.dto.request.oauth.NaverLoginParams;
 import com.example.modiraa.dto.response.SocialResponse;
 import com.example.modiraa.service.OAuthLoginService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
     private final OAuthLoginService oAuthLoginService;
+
+    // 소셜 회원 가입 요청 처리
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@ModelAttribute AdditionalInfoRequest request) throws IOException {
+        oAuthLoginService.createNewMember(request);
+        return ResponseEntity.ok("회원가입 완료");
+    }
 
     @PostMapping("/kakao")
     public ResponseEntity<SocialResponse> loginKakao(@RequestBody KakaoLoginParams params) {

--- a/src/main/java/com/example/modiraa/controller/MemberController.java
+++ b/src/main/java/com/example/modiraa/controller/MemberController.java
@@ -1,13 +1,10 @@
 package com.example.modiraa.controller;
 
 import com.example.modiraa.auth.UserDetailsImpl;
-import com.example.modiraa.dto.request.AdditionalInfoRequest;
 import com.example.modiraa.dto.response.LoginCheckResponse;
-import com.example.modiraa.service.OAuthLoginService;
-import com.example.modiraa.service.S3Uploader;
 import com.example.modiraa.service.MemberService;
+import com.example.modiraa.service.S3Uploader;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,20 +17,12 @@ import java.io.IOException;
 public class MemberController {
     private final S3Uploader s3Uploader;
     private final MemberService memberService;
-    private final OAuthLoginService oAuthLoginService;
 
     //S3 Test controller
     @PostMapping("/upload")
     @ResponseBody
     public String upload(@RequestParam("data") MultipartFile multipartFile) throws IOException {
         return s3Uploader.upload(multipartFile, "static");
-    }
-
-    // 소셜 회원 가입 요청 처리
-    @PostMapping("/signup")
-    public ResponseEntity<String> signup(@ModelAttribute AdditionalInfoRequest request) throws IOException {
-        oAuthLoginService.createNewMember(request);
-        return ResponseEntity.ok("회원가입 완료");
     }
 
     //로그인 유저 정보

--- a/src/main/java/com/example/modiraa/controller/MemberProfileController.java
+++ b/src/main/java/com/example/modiraa/controller/MemberProfileController.java
@@ -29,7 +29,7 @@ public class MemberProfileController {
 
     // 다른 유저 프로필 조회
     @GetMapping("/{id}")
-    public ResponseEntity<UserProfileResponse> profileRead(@PathVariable Long id) throws IllegalAccessException {
+    public ResponseEntity<UserProfileResponse> profileRead(@PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(memberProfileService.getProfile(id));
     }

--- a/src/main/java/com/example/modiraa/dto/ChatParticipantInfo.java
+++ b/src/main/java/com/example/modiraa/dto/ChatParticipantInfo.java
@@ -1,0 +1,13 @@
+package com.example.modiraa.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatParticipantInfo {
+    private Long roomParticipantId;
+    private Long participantId;
+}

--- a/src/main/java/com/example/modiraa/handler/ConnectCommandHandler.java
+++ b/src/main/java/com/example/modiraa/handler/ConnectCommandHandler.java
@@ -1,0 +1,22 @@
+package com.example.modiraa.handler;
+
+import com.example.modiraa.config.jwt.JwtAuthorizationFilter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+@Slf4j
+public class ConnectCommandHandler implements StompCommandHandler {
+    private final JwtAuthorizationFilter jwtAuthorizationFilter;
+
+    public ConnectCommandHandler(JwtAuthorizationFilter jwtAuthorizationFilter) {
+        this.jwtAuthorizationFilter = jwtAuthorizationFilter;
+    }
+
+    @Override
+    public void process(StompHeaderAccessor accessor, Message<?> message) {
+        String jwtToken = accessor.getFirstNativeHeader("Authorization");
+        log.info("CONNECT: {}", jwtToken);
+        jwtAuthorizationFilter.validateToken(jwtToken);
+    }
+}

--- a/src/main/java/com/example/modiraa/handler/ConnectCommandHandler.java
+++ b/src/main/java/com/example/modiraa/handler/ConnectCommandHandler.java
@@ -2,7 +2,6 @@ package com.example.modiraa.handler;
 
 import com.example.modiraa.config.jwt.JwtAuthorizationFilter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
 @Slf4j
@@ -14,7 +13,7 @@ public class ConnectCommandHandler implements StompCommandHandler {
     }
 
     @Override
-    public void process(StompHeaderAccessor accessor, Message<?> message) {
+    public void process(StompHeaderAccessor accessor) {
         String jwtToken = accessor.getFirstNativeHeader("Authorization");
         log.info("CONNECT: {}", jwtToken);
         jwtAuthorizationFilter.validateToken(jwtToken);

--- a/src/main/java/com/example/modiraa/handler/DisconnectCommandHandler.java
+++ b/src/main/java/com/example/modiraa/handler/DisconnectCommandHandler.java
@@ -22,7 +22,7 @@ public class DisconnectCommandHandler implements StompCommandHandler {
     @Override
     public void process(StompHeaderAccessor accessor) {
         // 연결이 종료된 클라이언트 sesssionId로 채팅방 id를 얻는다.
-        String sessionId = (String) accessor.getMessageHeaders().get("simpSessionId");
+        String sessionId = accessor.getSessionId();
         String roomCode = chatRoomService.getUserEnterRoomCode(sessionId);
 
         // 저장했던 sessionId 로 유저 객체를 받아옴

--- a/src/main/java/com/example/modiraa/handler/DisconnectCommandHandler.java
+++ b/src/main/java/com/example/modiraa/handler/DisconnectCommandHandler.java
@@ -6,7 +6,6 @@ import com.example.modiraa.model.Member;
 import com.example.modiraa.service.ChatMessageService;
 import com.example.modiraa.service.ChatRoomService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
 
@@ -21,7 +20,7 @@ public class DisconnectCommandHandler implements StompCommandHandler {
     }
 
     @Override
-    public void process(StompHeaderAccessor accessor, Message<?> message) {
+    public void process(StompHeaderAccessor accessor) {
         // 연결이 종료된 클라이언트 sesssionId로 채팅방 id를 얻는다.
         String sessionId = (String) accessor.getMessageHeaders().get("simpSessionId");
         String roomCode = chatRoomService.getUserEnterRoomCode(sessionId);

--- a/src/main/java/com/example/modiraa/handler/DisconnectCommandHandler.java
+++ b/src/main/java/com/example/modiraa/handler/DisconnectCommandHandler.java
@@ -1,0 +1,49 @@
+package com.example.modiraa.handler;
+
+import com.example.modiraa.dto.request.ChatMessageRequest;
+import com.example.modiraa.model.ChatMessage;
+import com.example.modiraa.model.Member;
+import com.example.modiraa.service.ChatMessageService;
+import com.example.modiraa.service.ChatRoomService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+
+@Slf4j
+public class DisconnectCommandHandler implements StompCommandHandler {
+    private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
+
+    public DisconnectCommandHandler(ChatRoomService chatRoomService, ChatMessageService chatMessageService) {
+        this.chatRoomService = chatRoomService;
+        this.chatMessageService = chatMessageService;
+    }
+
+    @Override
+    public void process(StompHeaderAccessor accessor, Message<?> message) {
+        // 연결이 종료된 클라이언트 sesssionId로 채팅방 id를 얻는다.
+        String sessionId = (String) accessor.getMessageHeaders().get("simpSessionId");
+        String roomCode = chatRoomService.getUserEnterRoomCode(sessionId);
+
+        // 저장했던 sessionId 로 유저 객체를 받아옴
+        Member member = chatRoomService.checkSessionUser(sessionId);
+
+        // 채팅방의 인원수를 -1
+        chatRoomService.minusUserCount(roomCode);
+        sendQuitMessage(roomCode, member);
+
+        // 퇴장한 클라이언트의 roomCode 맵핑 정보를 삭제
+        chatRoomService.removeUserEnterInfo(sessionId);
+
+        log.info("DISCONNECTED: sessionId={}, nickname={}, roomCode={}", sessionId, member.getNickname(), roomCode);
+    }
+
+    private void sendQuitMessage(String roomCode, Member member) {
+        chatMessageService.sendChatMessage(ChatMessageRequest.builder()
+                .type(ChatMessage.MessageType.QUIT)
+                .roomCode(roomCode)
+                .sender(member)
+                .build());
+    }
+}

--- a/src/main/java/com/example/modiraa/handler/StompCommandHandler.java
+++ b/src/main/java/com/example/modiraa/handler/StompCommandHandler.java
@@ -1,0 +1,8 @@
+package com.example.modiraa.handler;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+public interface StompCommandHandler {
+    void process(StompHeaderAccessor accessor, Message<?> message);
+}

--- a/src/main/java/com/example/modiraa/handler/StompCommandHandler.java
+++ b/src/main/java/com/example/modiraa/handler/StompCommandHandler.java
@@ -1,8 +1,7 @@
 package com.example.modiraa.handler;
 
-import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
 public interface StompCommandHandler {
-    void process(StompHeaderAccessor accessor, Message<?> message);
+    void process(StompHeaderAccessor accessor);
 }

--- a/src/main/java/com/example/modiraa/handler/StompHandler.java
+++ b/src/main/java/com/example/modiraa/handler/StompHandler.java
@@ -1,13 +1,9 @@
 package com.example.modiraa.handler;
 
 import com.example.modiraa.config.jwt.JwtAuthorizationFilter;
-import com.example.modiraa.dto.request.ChatMessageRequest;
-import com.example.modiraa.model.ChatMessage;
-import com.example.modiraa.model.Member;
 import com.example.modiraa.repository.MemberRepository;
 import com.example.modiraa.service.ChatMessageService;
 import com.example.modiraa.service.ChatRoomService;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -16,100 +12,32 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
 
-import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.HashMap;
+import java.util.Map;
 
 
 @Slf4j
-@RequiredArgsConstructor
 @Component
 public class StompHandler implements ChannelInterceptor {
+    private final Map<StompCommand, StompCommandHandler> commandHandlers = new HashMap<>();
 
-    private final JwtAuthorizationFilter jwtAuthorizationFilter;
-    private final ChatRoomService chatRoomService;
-    private final MemberRepository memberRepository;
-    private final ChatMessageService chatMessageService;
-
+    public StompHandler(JwtAuthorizationFilter jwtAuthorizationFilter,ChatRoomService chatRoomService,
+                        MemberRepository memberRepository,ChatMessageService chatMessageService) {
+        commandHandlers.put(StompCommand.CONNECT, new ConnectCommandHandler(jwtAuthorizationFilter));
+        commandHandlers.put(StompCommand.SUBSCRIBE, new SubscribeCommandHandler(jwtAuthorizationFilter, chatRoomService, memberRepository, chatMessageService));
+        commandHandlers.put(StompCommand.DISCONNECT, new DisconnectCommandHandler(chatRoomService, chatMessageService));
+    }
 
     @Override
-    // 클라이언트가 메세지를 발송하면 최초에 해당 메세지를 인터셉트하여 처리함
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
         StompCommand command = accessor.getCommand();
 
-        // websocket 연결시 헤더의 jwt token 검증
-        if (StompCommand.CONNECT == command) {
-            handleConnect(accessor);
-        } else if (StompCommand.SUBSCRIBE == command) {
-            handleSubscribe(accessor, message);
-        } else if (StompCommand.DISCONNECT == command) { // Websocket 연결 종료
-            handleDisconnect(accessor);
+        StompCommandHandler handler = commandHandlers.get(command);
+        if (handler != null) {
+            handler.process(accessor, message);
         }
+
         return message;
-    }
-
-    private void handleConnect(StompHeaderAccessor accessor) {
-        String jwtToken = accessor.getFirstNativeHeader("Authorization");
-        log.info("CONNECT: {}", jwtToken);
-        jwtAuthorizationFilter.validateToken(jwtToken);
-    }
-
-    private void handleSubscribe(StompHeaderAccessor accessor, Message<?> message) {
-        // header 정보에서 구독 destination 정보를 얻고, roomCode를 추출한다.
-        String roomCode = chatMessageService.getRoomCode(
-                Optional.ofNullable((String) message.getHeaders().get("simpDestination")).orElse("InvalidRoomCode"));
-        // 채팅방에 들어온 클라이언트 sessionId를 roomCode와 맵핑해 놓는다.(나중에 특정 세션이 어떤 채팅방에 들어가 있는지 알기 위함)
-        String sessionId = (String) message.getHeaders().get("simpSessionId");
-
-        String jwtToken = accessor.getFirstNativeHeader("Authorization");
-        if (jwtToken == null) {
-            throw new IllegalArgumentException("유효하지 않은 token 입니다.");
-        }
-
-        String nickname = jwtAuthorizationFilter.getNicknameFromJwt(jwtToken);
-        Member member = memberRepository.findByNickname(nickname, Member.class)
-                .orElseThrow(() -> new NoSuchElementException("nickname에 해당하는 member가 존재하지 않습니다: " + nickname));
-
-        chatRoomService.setUserEnterInfo(sessionId, member.getId(), roomCode);
-        chatRoomService.plusUserCount(roomCode); // 채팅방의 인원수를 +1
-
-        sendEnterMessage(roomCode, member);
-        log.info("SUBSCRIBED: sessionId={}, nickname={}, roomCode={}", sessionId, member.getNickname(), roomCode);
-
-    }
-
-    private void handleDisconnect(StompHeaderAccessor accessor) {
-        // 연결이 종료된 클라이언트 sesssionId로 채팅방 id를 얻는다.
-        String sessionId = (String) accessor.getMessageHeaders().get("simpSessionId");
-        String roomCode = chatRoomService.getUserEnterRoomCode(sessionId);
-
-        // 저장했던 sessionId 로 유저 객체를 받아옴
-        Member member = chatRoomService.checkSessionUser(sessionId);
-
-        // 채팅방의 인원수를 -1
-        chatRoomService.minusUserCount(roomCode);
-        sendQuitMessage(roomCode, member);
-
-        // 퇴장한 클라이언트의 roomCode 맵핑 정보를 삭제
-        chatRoomService.removeUserEnterInfo(sessionId);
-
-        log.info("DISCONNECTED: sessionId={}, nickname={}, roomCode={}", sessionId, member.getNickname(), roomCode);
-    }
-
-    private void sendEnterMessage(String roomCode, Member member) {
-        // 클라이언트 입장 메시지를 채팅방에 발송한다.(redis publish)
-        chatMessageService.sendChatMessage(ChatMessageRequest.builder()
-                .type(ChatMessage.MessageType.ENTER)
-                .roomCode(roomCode)
-                .sender(member)
-                .build());
-    }
-
-    private void sendQuitMessage(String roomCode, Member member) {
-        chatMessageService.sendChatMessage(ChatMessageRequest.builder()
-                .type(ChatMessage.MessageType.QUIT)
-                .roomCode(roomCode)
-                .sender(member)
-                .build());
     }
 }

--- a/src/main/java/com/example/modiraa/handler/StompHandler.java
+++ b/src/main/java/com/example/modiraa/handler/StompHandler.java
@@ -21,10 +21,9 @@ import java.util.Map;
 public class StompHandler implements ChannelInterceptor {
     private final Map<StompCommand, StompCommandHandler> commandHandlers = new HashMap<>();
 
-    public StompHandler(JwtAuthorizationFilter jwtAuthorizationFilter,ChatRoomService chatRoomService,
-                        MemberRepository memberRepository,ChatMessageService chatMessageService) {
+    public StompHandler(JwtAuthorizationFilter jwtAuthorizationFilter,ChatRoomService chatRoomService, ChatMessageService chatMessageService) {
         commandHandlers.put(StompCommand.CONNECT, new ConnectCommandHandler(jwtAuthorizationFilter));
-        commandHandlers.put(StompCommand.SUBSCRIBE, new SubscribeCommandHandler(jwtAuthorizationFilter, chatRoomService, memberRepository, chatMessageService));
+        commandHandlers.put(StompCommand.SUBSCRIBE, new SubscribeCommandHandler(jwtAuthorizationFilter, chatRoomService, chatMessageService));
         commandHandlers.put(StompCommand.DISCONNECT, new DisconnectCommandHandler(chatRoomService, chatMessageService));
     }
 

--- a/src/main/java/com/example/modiraa/handler/StompHandler.java
+++ b/src/main/java/com/example/modiraa/handler/StompHandler.java
@@ -1,7 +1,6 @@
 package com.example.modiraa.handler;
 
 import com.example.modiraa.config.jwt.JwtAuthorizationFilter;
-import com.example.modiraa.repository.MemberRepository;
 import com.example.modiraa.service.ChatMessageService;
 import com.example.modiraa.service.ChatRoomService;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +20,7 @@ import java.util.Map;
 public class StompHandler implements ChannelInterceptor {
     private final Map<StompCommand, StompCommandHandler> commandHandlers = new HashMap<>();
 
-    public StompHandler(JwtAuthorizationFilter jwtAuthorizationFilter,ChatRoomService chatRoomService, ChatMessageService chatMessageService) {
+    public StompHandler(JwtAuthorizationFilter jwtAuthorizationFilter, ChatRoomService chatRoomService, ChatMessageService chatMessageService) {
         commandHandlers.put(StompCommand.CONNECT, new ConnectCommandHandler(jwtAuthorizationFilter));
         commandHandlers.put(StompCommand.SUBSCRIBE, new SubscribeCommandHandler(jwtAuthorizationFilter, chatRoomService, chatMessageService));
         commandHandlers.put(StompCommand.DISCONNECT, new DisconnectCommandHandler(chatRoomService, chatMessageService));
@@ -34,7 +33,7 @@ public class StompHandler implements ChannelInterceptor {
 
         StompCommandHandler handler = commandHandlers.get(command);
         if (handler != null) {
-            handler.process(accessor, message);
+            handler.process(accessor);
         }
 
         return message;

--- a/src/main/java/com/example/modiraa/handler/SubscribeCommandHandler.java
+++ b/src/main/java/com/example/modiraa/handler/SubscribeCommandHandler.java
@@ -4,28 +4,24 @@ import com.example.modiraa.config.jwt.JwtAuthorizationFilter;
 import com.example.modiraa.dto.request.ChatMessageRequest;
 import com.example.modiraa.model.ChatMessage;
 import com.example.modiraa.model.Member;
-import com.example.modiraa.repository.MemberRepository;
 import com.example.modiraa.service.ChatMessageService;
 import com.example.modiraa.service.ChatRoomService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Slf4j
 public class SubscribeCommandHandler implements StompCommandHandler {
     private final JwtAuthorizationFilter jwtAuthorizationFilter;
     private final ChatRoomService chatRoomService;
-    private final MemberRepository memberRepository;
     private final ChatMessageService chatMessageService;
 
     public SubscribeCommandHandler(JwtAuthorizationFilter jwtAuthorizationFilter, ChatRoomService chatRoomService,
-                                   MemberRepository memberRepository, ChatMessageService chatMessageService) {
+                                   ChatMessageService chatMessageService) {
         this.jwtAuthorizationFilter = jwtAuthorizationFilter;
         this.chatRoomService = chatRoomService;
-        this.memberRepository = memberRepository;
         this.chatMessageService = chatMessageService;
     }
 
@@ -42,9 +38,7 @@ public class SubscribeCommandHandler implements StompCommandHandler {
             throw new IllegalArgumentException("유효하지 않은 token 입니다.");
         }
 
-        String nickname = jwtAuthorizationFilter.getNicknameFromJwt(jwtToken);
-        Member member = memberRepository.findByNickname(nickname, Member.class)
-                .orElseThrow(() -> new NoSuchElementException("nickname에 해당하는 member가 존재하지 않습니다: " + nickname));
+        Member member = jwtAuthorizationFilter.getMemberFromJwt(jwtToken);
 
         chatRoomService.setUserEnterInfo(sessionId, member.getId(), roomCode);
         chatRoomService.plusUserCount(roomCode); // 채팅방의 인원수를 +1

--- a/src/main/java/com/example/modiraa/handler/SubscribeCommandHandler.java
+++ b/src/main/java/com/example/modiraa/handler/SubscribeCommandHandler.java
@@ -7,7 +7,6 @@ import com.example.modiraa.model.Member;
 import com.example.modiraa.service.ChatMessageService;
 import com.example.modiraa.service.ChatRoomService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
 import java.util.Optional;
@@ -26,7 +25,7 @@ public class SubscribeCommandHandler implements StompCommandHandler {
     }
 
     @Override
-    public void process(StompHeaderAccessor accessor, Message<?> message) {
+    public void process(StompHeaderAccessor accessor) {
         String jwtToken = accessor.getFirstNativeHeader("Authorization");
         jwtAuthorizationFilter.validateToken(jwtToken);
 

--- a/src/main/java/com/example/modiraa/handler/SubscribeCommandHandler.java
+++ b/src/main/java/com/example/modiraa/handler/SubscribeCommandHandler.java
@@ -1,0 +1,64 @@
+package com.example.modiraa.handler;
+
+import com.example.modiraa.config.jwt.JwtAuthorizationFilter;
+import com.example.modiraa.dto.request.ChatMessageRequest;
+import com.example.modiraa.model.ChatMessage;
+import com.example.modiraa.model.Member;
+import com.example.modiraa.repository.MemberRepository;
+import com.example.modiraa.service.ChatMessageService;
+import com.example.modiraa.service.ChatRoomService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Slf4j
+public class SubscribeCommandHandler implements StompCommandHandler {
+    private final JwtAuthorizationFilter jwtAuthorizationFilter;
+    private final ChatRoomService chatRoomService;
+    private final MemberRepository memberRepository;
+    private final ChatMessageService chatMessageService;
+
+    public SubscribeCommandHandler(JwtAuthorizationFilter jwtAuthorizationFilter, ChatRoomService chatRoomService,
+                                   MemberRepository memberRepository, ChatMessageService chatMessageService) {
+        this.jwtAuthorizationFilter = jwtAuthorizationFilter;
+        this.chatRoomService = chatRoomService;
+        this.memberRepository = memberRepository;
+        this.chatMessageService = chatMessageService;
+    }
+
+    @Override
+    public void process(StompHeaderAccessor accessor, Message<?> message) {
+        // header 정보에서 구독 destination 정보를 얻고, roomCode를 추출한다.
+        String roomCode = chatMessageService.getRoomCode(
+                Optional.ofNullable((String) message.getHeaders().get("simpDestination")).orElse("InvalidRoomCode"));
+        // 채팅방에 들어온 클라이언트 sessionId를 roomCode와 맵핑해 놓는다.(나중에 특정 세션이 어떤 채팅방에 들어가 있는지 알기 위함)
+        String sessionId = (String) message.getHeaders().get("simpSessionId");
+
+        String jwtToken = accessor.getFirstNativeHeader("Authorization");
+        if (jwtToken == null) {
+            throw new IllegalArgumentException("유효하지 않은 token 입니다.");
+        }
+
+        String nickname = jwtAuthorizationFilter.getNicknameFromJwt(jwtToken);
+        Member member = memberRepository.findByNickname(nickname, Member.class)
+                .orElseThrow(() -> new NoSuchElementException("nickname에 해당하는 member가 존재하지 않습니다: " + nickname));
+
+        chatRoomService.setUserEnterInfo(sessionId, member.getId(), roomCode);
+        chatRoomService.plusUserCount(roomCode); // 채팅방의 인원수를 +1
+
+        sendEnterMessage(roomCode, member);
+        log.info("SUBSCRIBED: sessionId={}, nickname={}, roomCode={}", sessionId, member.getNickname(), roomCode);
+    }
+
+    private void sendEnterMessage(String roomCode, Member member) {
+        // 클라이언트 입장 메시지를 채팅방에 발송한다.(redis publish)
+        chatMessageService.sendChatMessage(ChatMessageRequest.builder()
+                .type(ChatMessage.MessageType.ENTER)
+                .roomCode(roomCode)
+                .sender(member)
+                .build());
+    }
+}

--- a/src/main/java/com/example/modiraa/model/ChatMessage.java
+++ b/src/main/java/com/example/modiraa/model/ChatMessage.java
@@ -22,17 +22,18 @@ public class ChatMessage extends Timestamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
-    @Enumerated(value = EnumType.STRING)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private MessageType type;
-
-    // 채팅방 코드
-    @Column
-    private String roomCode;
 
     // 메시지
     @Column(length = 100000)
     private String message;
+
+    // 채팅방 코드
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
 
     // 메시지 보낸사람
     @ManyToOne(fetch = FetchType.LAZY)
@@ -40,10 +41,10 @@ public class ChatMessage extends Timestamped {
     private Member sender;
 
     @Builder
-    public ChatMessage(MessageType type, String roomCode, Member sender, String message) {
+    public ChatMessage(MessageType type, String message, ChatRoom chatRoom, Member sender) {
         this.type = type;
-        this.roomCode = roomCode;
-        this.sender = sender;
         this.message = message;
+        this.chatRoom = chatRoom;
+        this.sender = sender;
     }
 }

--- a/src/main/java/com/example/modiraa/model/ChatMessage.java
+++ b/src/main/java/com/example/modiraa/model/ChatMessage.java
@@ -30,7 +30,7 @@ public class ChatMessage extends Timestamped {
     @Column(length = 100000)
     private String message;
 
-    // 채팅방 코드
+    // 채팅방
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;

--- a/src/main/java/com/example/modiraa/model/ChatRoom.java
+++ b/src/main/java/com/example/modiraa/model/ChatRoom.java
@@ -16,7 +16,6 @@ public class ChatRoom implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "chatroom_id")
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/modiraa/model/Post.java
+++ b/src/main/java/com/example/modiraa/model/Post.java
@@ -1,5 +1,6 @@
 package com.example.modiraa.model;
 
+import com.example.modiraa.enums.CategoryType;
 import com.example.modiraa.enums.GenderType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,9 +21,10 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //음식 카테고리
+    //카테고리
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String category;
+    private CategoryType category;
 
     //제목
     @Column(nullable = false)
@@ -78,7 +80,7 @@ public class Post {
 
 
     @Builder
-    public Post(String category, String title, String contents, String address, double latitude, double longitude, LocalDate date,
+    public Post(CategoryType category, String title, String contents, String address, double latitude, double longitude, LocalDate date,
                 LocalTime time, GenderType gender, int ageMin, int ageMax, Member owner, PostImage postImage, ChatRoom chatRoom) {
         this.category = category;
         this.title = title;

--- a/src/main/java/com/example/modiraa/model/PostImage.java
+++ b/src/main/java/com/example/modiraa/model/PostImage.java
@@ -12,8 +12,8 @@ import javax.persistence.*;
 @AllArgsConstructor
 public class PostImage {
 
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/modiraa/model/Rating.java
+++ b/src/main/java/com/example/modiraa/model/Rating.java
@@ -15,7 +15,6 @@ public class Rating {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "rating_id", nullable = false)
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/modiraa/model/RoomParticipant.java
+++ b/src/main/java/com/example/modiraa/model/RoomParticipant.java
@@ -13,9 +13,8 @@ import javax.persistence.*;
 @AllArgsConstructor
 public class RoomParticipant {
 
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
-    @Column(name = "member_room_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -23,7 +22,7 @@ public class RoomParticipant {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chatroom_id")
+    @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;
 
 

--- a/src/main/java/com/example/modiraa/pubsub/RedisSubscriber.java
+++ b/src/main/java/com/example/modiraa/pubsub/RedisSubscriber.java
@@ -2,8 +2,12 @@ package com.example.modiraa.pubsub;
 
 import com.example.modiraa.dto.request.ChatMessageRequest;
 import com.example.modiraa.dto.response.ChatMessageResponse;
+import com.example.modiraa.exception.CustomException;
+import com.example.modiraa.exception.ErrorCode;
 import com.example.modiraa.model.ChatMessage;
+import com.example.modiraa.model.ChatRoom;
 import com.example.modiraa.repository.ChatMessageRepository;
+import com.example.modiraa.repository.ChatRoomRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +21,7 @@ public class RedisSubscriber {
 
     private final ObjectMapper objectMapper;
     private final SimpMessageSendingOperations messagingTemplate;
+    private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
 
 
@@ -27,9 +32,12 @@ public class RedisSubscriber {
 
             messagingTemplate.convertAndSend("/sub/chat/room/" + chatMessage.getRoomCode(), getPayload(chatMessage));
 
+            ChatRoom chatRoom = chatRoomRepository.findByRoomCode(chatMessage.getRoomCode())
+                    .orElseThrow(() -> new CustomException(ErrorCode.ROOM_CODE_NOT_FOUND));
+
             ChatMessage message = ChatMessage.builder()
                     .type(chatMessage.getType())
-                    .roomCode(chatMessage.getRoomCode())
+                    .chatRoom(chatRoom)
                     .sender(chatMessage.getSender())
                     .message(chatMessage.getMessage())
                     .build();

--- a/src/main/java/com/example/modiraa/repository/ChatMessageQueryRepository.java
+++ b/src/main/java/com/example/modiraa/repository/ChatMessageQueryRepository.java
@@ -2,14 +2,20 @@ package com.example.modiraa.repository;
 
 import com.example.modiraa.model.ChatMessage;
 import com.querydsl.core.QueryResults;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 import static com.example.modiraa.model.QChatMessage.chatMessage;
+import static com.example.modiraa.model.QPost.post;
+import static com.example.modiraa.model.QPostImage.postImage;
 
 @RequiredArgsConstructor
 @Repository
@@ -17,14 +23,19 @@ public class ChatMessageQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     public Page<ChatMessage> findByRoomCodeOrderByIdDesc(String roomCode, Pageable pageable) {
-        QueryResults<ChatMessage> result = queryFactory.selectFrom(chatMessage)
+        List<ChatMessage> result = queryFactory.selectFrom(chatMessage)
                 .where(chatMessage.roomCode.eq(roomCode))
                 .orderBy(chatMessage.id.desc())
-                .join(chatMessage.sender)
-                .fetchJoin()
+                .join(chatMessage.sender).fetchJoin()
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .fetchResults();
-        return new PageImpl<>(result.getResults(), pageable, result.getTotal());
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(chatMessage.count())
+                .from(chatMessage)
+                .where(chatMessage.roomCode.eq(roomCode));
+
+        return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
 }

--- a/src/main/java/com/example/modiraa/repository/ChatMessageQueryRepository.java
+++ b/src/main/java/com/example/modiraa/repository/ChatMessageQueryRepository.java
@@ -1,12 +1,10 @@
 package com.example.modiraa.repository;
 
 import com.example.modiraa.model.ChatMessage;
-import com.querydsl.core.QueryResults;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
@@ -14,8 +12,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 import static com.example.modiraa.model.QChatMessage.chatMessage;
-import static com.example.modiraa.model.QPost.post;
-import static com.example.modiraa.model.QPostImage.postImage;
 
 @RequiredArgsConstructor
 @Repository

--- a/src/main/java/com/example/modiraa/repository/ChatMessageQueryRepository.java
+++ b/src/main/java/com/example/modiraa/repository/ChatMessageQueryRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 import static com.example.modiraa.model.QChatMessage.chatMessage;
+import static com.example.modiraa.model.QChatRoom.chatRoom;
 
 @RequiredArgsConstructor
 @Repository
@@ -20,9 +21,10 @@ public class ChatMessageQueryRepository {
 
     public Page<ChatMessage> findByRoomCodeOrderByIdDesc(String roomCode, Pageable pageable) {
         List<ChatMessage> result = queryFactory.selectFrom(chatMessage)
-                .where(chatMessage.roomCode.eq(roomCode))
-                .orderBy(chatMessage.id.desc())
+                .join(chatMessage.chatRoom).fetchJoin()
                 .join(chatMessage.sender).fetchJoin()
+                .where(chatMessage.chatRoom.roomCode.eq(roomCode))
+                .orderBy(chatMessage.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -30,7 +32,8 @@ public class ChatMessageQueryRepository {
         JPAQuery<Long> countQuery = queryFactory
                 .select(chatMessage.count())
                 .from(chatMessage)
-                .where(chatMessage.roomCode.eq(roomCode));
+                .join(chatMessage.chatRoom, chatRoom)
+                .where(chatRoom.roomCode.eq(roomCode));
 
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/com/example/modiraa/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/example/modiraa/repository/PostRepositoryImpl.java
@@ -43,8 +43,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .select(post.count())
                 .from(post)
                 .join(post.postImage, postImage)
-                .where(post.id.lt(lastId)
-                        .and(post.address.contains(address))
+                .where(post.address.contains(address)
                         .and(post.postImage.menu.contains(keyword)
                                 .or(post.title.contains(keyword))
                                 .or(post.contents.contains(keyword))
@@ -68,7 +67,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         JPAQuery<Long> countQuery = queryFactory
                 .select(post.count())
                 .from(post)
-                .where(post.id.lt(lastId).and(post.category.contains(category)));
+                .where(post.category.contains(category));
 
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/com/example/modiraa/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/example/modiraa/repository/PostRepositoryImpl.java
@@ -58,7 +58,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         List<Post> result = queryFactory.selectFrom(post)
                 .join(post.postImage).fetchJoin()
                 .join(post.chatRoom).fetchJoin()
-                .where(post.id.lt(lastId).and(post.category.contains(category)))
+                .where(post.id.lt(lastId).and(post.category.stringValue().contains(category)))
                 .orderBy(post.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -67,7 +67,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         JPAQuery<Long> countQuery = queryFactory
                 .select(post.count())
                 .from(post)
-                .where(post.category.contains(category));
+                .where(post.category.stringValue().contains(category));
 
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
@@ -94,7 +94,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         List<Post> result = queryFactory.selectFrom(post)
                 .join(post.postImage).fetchJoin()
                 .join(post.chatRoom).fetchJoin()
-                .where(post.category.contains(category))
+                .where(post.category.stringValue().contains(category))
                 .orderBy(post.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -103,7 +103,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         JPAQuery<Long> countQuery = queryFactory
                 .select(post.count())
                 .from(post)
-                .where(post.category.contains(category));
+                .where(post.category.stringValue().contains(category));
 
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
@@ -133,7 +133,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .join(post.postImage).fetchJoin()
                 .join(post.chatRoom).fetchJoin()
                 .where(post.address.contains(address)
-                        .and(post.category.contains(category)))
+                        .and(post.category.stringValue().contains(category)))
                 .orderBy(post.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -143,7 +143,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .select(post.count())
                 .from(post)
                 .where(post.address.contains(address)
-                        .and(post.category.contains(category)));
+                        .and(post.category.stringValue().contains(category)));
 
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/com/example/modiraa/repository/RoomParticipantRepositoryCustom.java
+++ b/src/main/java/com/example/modiraa/repository/RoomParticipantRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.example.modiraa.repository;
 
 import com.example.modiraa.dto.response.JoinedMembersResponse;
 import com.example.modiraa.dto.response.JoinedPostsResponse;
+import com.example.modiraa.dto.ChatParticipantInfo;
 import com.example.modiraa.model.RoomParticipant;
 import com.example.modiraa.model.Member;
 
@@ -9,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface RoomParticipantRepositoryCustom {
-    List<RoomParticipant> findByChatRoomId(Long chatroomId);
+    List<ChatParticipantInfo> findByChatRoomId(Long chatroomId);
 
     Optional<RoomParticipant> findTopByMemberOrderByIdDesc(Member member);
 

--- a/src/main/java/com/example/modiraa/repository/RoomParticipantRepositoryImpl.java
+++ b/src/main/java/com/example/modiraa/repository/RoomParticipantRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.example.modiraa.repository;
 
+import com.example.modiraa.dto.ChatParticipantInfo;
 import com.example.modiraa.dto.response.JoinedMembersResponse;
 import com.example.modiraa.dto.response.JoinedPostsResponse;
 import com.example.modiraa.model.Member;
@@ -18,18 +19,22 @@ import static com.example.modiraa.model.QPost.post;
 import static com.example.modiraa.model.QPostImage.postImage;
 import static com.example.modiraa.model.QRoomParticipant.roomParticipant;
 
-@RequiredArgsConstructor
 @Repository
+@RequiredArgsConstructor
 public class RoomParticipantRepositoryImpl implements RoomParticipantRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<RoomParticipant> findByChatRoomId(Long chatroomId) {
-        return queryFactory.selectFrom(roomParticipant)
+    public List<ChatParticipantInfo> findByChatRoomId(Long chatroomId) {
+        return queryFactory
+                .select(Projections.constructor(
+                        ChatParticipantInfo.class,
+                        roomParticipant.id,
+                        member.id))
+                .from(roomParticipant)
+                .join(roomParticipant.member, member)
+                .join(roomParticipant.chatRoom, chatRoom)
                 .where(roomParticipant.chatRoom.id.eq(chatroomId))
-                .join(roomParticipant.member)
-                .join(roomParticipant.chatRoom)
-                .fetchJoin()
                 .fetch();
     }
 

--- a/src/main/java/com/example/modiraa/service/ChatMessageService.java
+++ b/src/main/java/com/example/modiraa/service/ChatMessageService.java
@@ -65,7 +65,7 @@ public class ChatMessageService {
         return postSlice.map(p ->
                 ChatMessageResponse.builder()
                         .type(p.getType())
-                        .roomCode(p.getRoomCode())
+                        .roomCode(p.getChatRoom().getRoomCode())
                         .senderId(p.getSender().getId())
                         .senderNickname(p.getSender().getNickname())
                         .profileImage(p.getSender().getProfileImage())

--- a/src/main/java/com/example/modiraa/service/PostReadService.java
+++ b/src/main/java/com/example/modiraa/service/PostReadService.java
@@ -98,7 +98,7 @@ public class PostReadService {
                 PostsResponse.builder()
                         .postId(p.getId())
                         .title(p.getTitle())
-                        .category(p.getCategory())
+                        .category(p.getCategory().getValue())
                         .date(p.getDate().format(DateTimeFormatter.ofPattern("yyyy/MM/dd")))
                         .time(p.getTime().format(DateTimeFormatter.ofPattern("a h시 m분")))
                         .maxParticipant(p.getChatRoom().getMaxParticipant())
@@ -123,7 +123,7 @@ public class PostReadService {
         String formatTime = post.getTime().format(DateTimeFormatter.ofPattern("a h시 m분"));
 
         return PostDetailResponse.builder()
-                .category(post.getCategory())
+                .category(post.getCategory().getValue())
                 .title(post.getTitle())
                 .contents(post.getContents())
                 .restaurantAddress(post.getAddress())

--- a/src/main/java/com/example/modiraa/service/PostReadService.java
+++ b/src/main/java/com/example/modiraa/service/PostReadService.java
@@ -40,9 +40,6 @@ public class PostReadService {
 
         Page<Post> posts = postRepository.findBySearchKeywordAndAddress(lastId, address, keyword, pageable);
 
-        log.info("result=> {}", posts);
-        log.info("result=> {}", posts.getContent());
-
         return postResponseDto(posts);
     }
 
@@ -52,9 +49,6 @@ public class PostReadService {
         log.info("lastId -> {}", lastId);
 
         Page<Post> posts = postRepository.findByIdLessThanAndCategory(lastId, category, pageable);
-
-        log.info("result=> {}", posts);
-        log.info("result=> {}", posts.getContent());
 
         return postResponseDto(posts);
     }

--- a/src/main/java/com/example/modiraa/service/PostService.java
+++ b/src/main/java/com/example/modiraa/service/PostService.java
@@ -3,6 +3,7 @@ package com.example.modiraa.service;
 import com.example.modiraa.auth.UserDetailsImpl;
 import com.example.modiraa.dto.ChatParticipantInfo;
 import com.example.modiraa.dto.request.PostRequest;
+import com.example.modiraa.enums.CategoryType;
 import com.example.modiraa.enums.GenderType;
 import com.example.modiraa.exception.CustomException;
 import com.example.modiraa.exception.ErrorCode;
@@ -85,7 +86,7 @@ public class PostService {
         }
 
         Post post = Post.builder()
-                .category(postRequest.getCategory())
+                .category(CategoryType.fromValue(postRequest.getCategory()))
                 .title(postRequest.getTitle())
                 .contents(postRequest.getContents())
                 .address(postRequest.getAddress())

--- a/src/main/java/com/example/modiraa/service/PostService.java
+++ b/src/main/java/com/example/modiraa/service/PostService.java
@@ -1,6 +1,7 @@
 package com.example.modiraa.service;
 
 import com.example.modiraa.auth.UserDetailsImpl;
+import com.example.modiraa.dto.ChatParticipantInfo;
 import com.example.modiraa.dto.request.PostRequest;
 import com.example.modiraa.enums.GenderType;
 import com.example.modiraa.exception.CustomException;
@@ -57,12 +58,12 @@ public class PostService {
 
         checkPostDeletionPermission(post, memberId);
 
-        List<RoomParticipant> roomParticipantList = roomParticipantRepository.findByChatRoomId(chatRoomId);
+        List<ChatParticipantInfo> chatParticipantInfoList = roomParticipantRepository.findByChatRoomId(chatRoomId);
 
-        for (RoomParticipant roomParticipant : roomParticipantList) {
-            roomParticipantRepository.deleteById(roomParticipant.getId());
+        for (ChatParticipantInfo chatParticipantInfo : chatParticipantInfoList) {
+            roomParticipantRepository.deleteById(chatParticipantInfo.getRoomParticipantId());
 
-            Member member = memberRepository.findById(roomParticipant.getMember().getId())
+            Member member = memberRepository.findById(chatParticipantInfo.getParticipantId())
                     .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
             updateMemberPostStatus(member, null);

--- a/src/test/java/com/example/modiraa/repository/ChatMessageQueryRepositoryTest.java
+++ b/src/test/java/com/example/modiraa/repository/ChatMessageQueryRepositoryTest.java
@@ -41,18 +41,12 @@ class ChatMessageQueryRepositoryTest {
         ChatRoom chatRoom1 = new ChatRoom(5);
         ChatRoom chatRoom2 = new ChatRoom(6);
 
-        ChatMessage chatMessage1 = new ChatMessage(ChatMessage.MessageType.ENTER,
-                chatRoom1.getRoomCode(), member1, "message1");
-        ChatMessage chatMessage2 = new ChatMessage(ChatMessage.MessageType.TALK,
-                chatRoom1.getRoomCode(), member1, "message2");
-        ChatMessage chatMessage3 = new ChatMessage(ChatMessage.MessageType.TALK,
-                chatRoom1.getRoomCode(), member1, "message3");
-        ChatMessage chatMessage4 = new ChatMessage(ChatMessage.MessageType.TALK,
-                chatRoom2.getRoomCode(), member2, "message4");
-        ChatMessage chatMessage5 = new ChatMessage(ChatMessage.MessageType.TALK,
-                chatRoom2.getRoomCode(), member2, "message5");
-        ChatMessage chatMessage6 = new ChatMessage(ChatMessage.MessageType.TALK,
-                chatRoom2.getRoomCode(), member2, "message6");
+        ChatMessage chatMessage1 = new ChatMessage(ChatMessage.MessageType.ENTER, "message1", chatRoom1, member1);
+        ChatMessage chatMessage2 = new ChatMessage(ChatMessage.MessageType.TALK, "message2", chatRoom1, member1);
+        ChatMessage chatMessage3 = new ChatMessage(ChatMessage.MessageType.TALK, "message3", chatRoom1, member1);
+        ChatMessage chatMessage4 = new ChatMessage(ChatMessage.MessageType.TALK, "message4", chatRoom2, member2);
+        ChatMessage chatMessage5 = new ChatMessage(ChatMessage.MessageType.TALK, "message5", chatRoom2, member2);
+        ChatMessage chatMessage6 = new ChatMessage(ChatMessage.MessageType.TALK, "message6", chatRoom2, member2);
 
         em.persist(member1);
         em.persist(member2);

--- a/src/test/java/com/example/modiraa/repository/PostRepositoryTest.java
+++ b/src/test/java/com/example/modiraa/repository/PostRepositoryTest.java
@@ -3,6 +3,7 @@ package com.example.modiraa.repository;
 import com.example.modiraa.config.TestQuerydslConfig;
 import com.example.modiraa.dto.request.oauth.OAuthProvider;
 import com.example.modiraa.dto.response.MyPostsResponse;
+import com.example.modiraa.enums.CategoryType;
 import com.example.modiraa.enums.GenderType;
 import com.example.modiraa.model.ChatRoom;
 import com.example.modiraa.model.Member;
@@ -55,11 +56,11 @@ class PostRepositoryTest {
         ChatRoom chatRoom2 = new ChatRoom(20);
         ChatRoom chatRoom3 = new ChatRoom(30);
 
-        Post post1 = new Post("골든벨", "title1", "contents1", "서울 성동구", 1.1, 1.1,
+        Post post1 = new Post(CategoryType.GOLDEN_BELL, "title1", "contents1", "서울 성동구", 1.1, 1.1,
                 LocalDate.now(), LocalTime.now(), GenderType.MALE, 10, 20, member1, postImage1, chatRoom1);
-        Post post2 = new Post("N빵", "title2", "contents2", "서울 용산구", 2.2, 2.2,
+        Post post2 = new Post(CategoryType.DUTCH_PAY, "title2", "contents2", "서울 용산구", 2.2, 2.2,
                 LocalDate.now(), LocalTime.now(), GenderType.MALE, 20, 30, member1, postImage2, chatRoom2);
-        Post post3 = new Post("N빵", "title3", "contents3", "서울 동대문구", 3.3, 3.3,
+        Post post3 = new Post(CategoryType.DUTCH_PAY, "title3", "contents3", "서울 동대문구", 3.3, 3.3,
                 LocalDate.now(), LocalTime.now(), GenderType.FEMALE, 30, 40, member3, postImage2, chatRoom3);
 
         em.persist(member1);
@@ -88,7 +89,7 @@ class PostRepositoryTest {
         Member member1 = em.find(Member.class, 1L);
         PostImage postImage1 = em.find(PostImage.class, 1L);
         ChatRoom chatRoom1 = em.find(ChatRoom.class, 1L);
-        Post post1 = new Post("category1", "title1", "contents1", "address1", 1.1, 1.1,
+        Post post1 = new Post(CategoryType.DUTCH_PAY, "title1", "contents1", "address1", 1.1, 1.1,
                 LocalDate.now(), LocalTime.now(), GenderType.MALE, 10, 20, member1, postImage1, chatRoom1);
 
         // When
@@ -183,8 +184,8 @@ class PostRepositoryTest {
     public void testFindByIdLessThanAndCategory() {
         // Given
         Long lastId = 100L;
-        String goldenBellCategory = "골든벨";
-        String dutchPayCategory = "N빵";
+        String goldenBellCategory = "GOLDEN_BELL";
+        String dutchPayCategory = "DUTCH_PAY";
         Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "id"));
 
         // When
@@ -225,8 +226,8 @@ class PostRepositoryTest {
     @DisplayName("카테고리별 Post 조회")
     public void testFindByCategory() {
         // Given
-        String goldenBellCategory = "골든벨";
-        String dutchPayCategory = "N빵";
+        String goldenBellCategory = "GOLDEN_BELL";
+        String dutchPayCategory = "DUTCH_PAY";
         Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "id"));
 
         // When
@@ -271,7 +272,7 @@ class PostRepositoryTest {
     public void testFindByAddressAndCategory() {
         // Given
         String memberAddress = "서울";
-        String goldenBellCategory = "골든벨";
+        String goldenBellCategory = "GOLDEN_BELL";
         Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "id"));
 
         // When

--- a/src/test/java/com/example/modiraa/repository/RoomParticipantRepositoryTest.java
+++ b/src/test/java/com/example/modiraa/repository/RoomParticipantRepositoryTest.java
@@ -5,6 +5,7 @@ import com.example.modiraa.dto.ChatParticipantInfo;
 import com.example.modiraa.dto.request.oauth.OAuthProvider;
 import com.example.modiraa.dto.response.JoinedMembersResponse;
 import com.example.modiraa.dto.response.JoinedPostsResponse;
+import com.example.modiraa.enums.CategoryType;
 import com.example.modiraa.enums.GenderType;
 import com.example.modiraa.model.*;
 import org.junit.jupiter.api.AfterEach;
@@ -51,11 +52,11 @@ class RoomParticipantRepositoryTest {
         ChatRoom chatRoom2 = new ChatRoom(4);
         ChatRoom chatRoom3 = new ChatRoom(5);
 
-        Post post1 = new Post("골든벨", "title1", "contents1", "서울 성동구", 1.1, 1.1,
+        Post post1 = new Post(CategoryType.GOLDEN_BELL, "title1", "contents1", "서울 성동구", 1.1, 1.1,
                 LocalDate.now(), LocalTime.now(), GenderType.MALE, 10, 20, member1, postImage1, chatRoom1);
-        Post post2 = new Post("N빵", "title2", "contents2", "서울 용산구", 2.2, 2.2,
+        Post post2 = new Post(CategoryType.DUTCH_PAY, "title2", "contents2", "서울 용산구", 2.2, 2.2,
                 LocalDate.now(), LocalTime.now(), GenderType.MALE, 20, 30, member2, postImage2, chatRoom2);
-        Post post3 = new Post("N빵", "title3", "contents3", "서울 동대문구", 3.3, 3.3,
+        Post post3 = new Post(CategoryType.DUTCH_PAY, "title3", "contents3", "서울 동대문구", 3.3, 3.3,
                 LocalDate.now(), LocalTime.now(), GenderType.FEMALE, 30, 40, member3, postImage2, chatRoom3);
 
         RoomParticipant roomParticipant1 = new RoomParticipant(member2, chatRoom1);

--- a/src/test/java/com/example/modiraa/repository/RoomParticipantRepositoryTest.java
+++ b/src/test/java/com/example/modiraa/repository/RoomParticipantRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.example.modiraa.repository;
 
 import com.example.modiraa.config.TestQuerydslConfig;
+import com.example.modiraa.dto.ChatParticipantInfo;
 import com.example.modiraa.dto.request.oauth.OAuthProvider;
 import com.example.modiraa.dto.response.JoinedMembersResponse;
 import com.example.modiraa.dto.response.JoinedPostsResponse;
@@ -113,11 +114,17 @@ class RoomParticipantRepositoryTest {
         RoomParticipant roomParticipant3 = em.find(RoomParticipant.class, 3L);
 
         // When
-        List<RoomParticipant> result = repository.findByChatRoomId(chatRoom1.getId());
+        List<ChatParticipantInfo> result = repository.findByChatRoomId(chatRoom1.getId());
 
         // Then
         assertThat(result.size()).isEqualTo(3);
-        assertThat(result).containsExactly(roomParticipant1, roomParticipant2, roomParticipant3);
+        assertThat(result)
+                .extracting("roomParticipantId")
+                .containsExactly(roomParticipant1.getId(), roomParticipant2.getId(), roomParticipant3.getId());
+        assertThat(result)
+                .extracting("participantId")
+                .containsExactly(roomParticipant1.getMember().getId(), roomParticipant2.getMember().getId(), roomParticipant3.getMember().getId());
+
     }
 
     @Test


### PR DESCRIPTION
Refactor: findByRoomCodeOrderByIdDesc 쿼리 메소드 개선
Refactor: 채팅 참여자 조회에 대한 쿼리 반환을 DTO로 변경
Refactor: 커맨드 핸들러를 적용하여 StompHandler 리팩토링
Refactor: getNicknameFromJwt에서 getMemberFromJwt 메소드로 사용변경
Refactor: SubscribeCommandHandler의 process 메서드 리팩토링
Refactor: process 메서드에서 Message<?> 파라미터 제거
Refactor: getSessionId()를 사용한 세션 ID 추출로 변경
Fix: countQuery 수정 where문에서 lastId 제거
Refactor: 불필요한 로깅을 제거
Refactor: 소셜 회원 가입 MemberController에서 AuthController로 이동
Refactor: 불필요한 코드 제거
Refactor: 컬럼 네이밍 변경 및 ChatMessage와 ChatRoom 연관관계 설정
Comment: 주석 수정
Refactor: Category Enum으로 변경
Test: 테이블 변경으로 인해 테스트 코드 수정